### PR TITLE
Updating project to eliminate deprecations and errors due to latest Y…

### DIFF
--- a/libraries/include/iCub/eventdriven/vBottle.h
+++ b/libraries/include/iCub/eventdriven/vBottle.h
@@ -223,7 +223,7 @@ private:
     void addList();
     void addString();
     void addVocab();
-    void fromString(const yarp::os::ConstString& text);
+    void fromString(const std::string& text);
     void append(const yarp::os::Bottle &alt);
     void copy();
     void copyPortable();
@@ -238,7 +238,7 @@ private:
 
 
     int getInt();
-    yarp::os::ConstString getString();
+    std::string getString();
     double getDouble();
     Bottle* getList();
     yarp::os::Value& get();
@@ -255,14 +255,14 @@ class vBottleMimic : public yarp::os::Portable {
 private:
 
     //headers
-    std::vector<YARP_INT32> header1;
+    std::vector<std::int32_t> header1;
     std::string header2;
-    std::vector<YARP_INT32> header3;
+    std::vector<std::int32_t> header3;
 
     //data
     const char * datablock;
     unsigned int datalength; //<- set the number of bytes here
-    std::vector<YARP_INT32> internaldata;
+    std::vector<std::int32_t> internaldata;
 
     //sizes
     unsigned int elementINTS;
@@ -280,7 +280,7 @@ public:
         header3.push_back(BOTTLE_TAG_LIST|BOTTLE_TAG_INT); // bottle code + specialisation with ints
         header3.push_back(0); // <- set the number of ints here (e.g. 2 * #v's)
         elementINTS = 2;
-        elementBYTES = sizeof(YARP_INT32) * elementINTS;
+        elementBYTES = sizeof(std::int32_t) * elementINTS;
     }
 
     /// \brief for data already allocated in contiguous space. Just send this
@@ -321,7 +321,7 @@ public:
         event<> v = ev::createEvent(eventtype);
         v->encode(temp);
         elementINTS = temp.size();
-        elementBYTES = sizeof(YARP_INT32) * elementINTS;
+        elementBYTES = sizeof(std::int32_t) * elementINTS;
 
     }
 
@@ -334,10 +334,10 @@ public:
     virtual bool write(yarp::os::ConnectionWriter& connection) {
 
         connection.appendBlock((const char *)header1.data(),
-                                       header1.size() * sizeof(YARP_INT32));
+                                       header1.size() * sizeof(std::int32_t));
         connection.appendBlock(header2.c_str(), header1[3]);
         connection.appendBlock((const char *)header3.data(),
-                                       header3.size() * sizeof(YARP_INT32));
+                                       header3.size() * sizeof(std::int32_t));
         connection.appendBlock(datablock, datalength);
 
         return !connection.isError();

--- a/libraries/include/iCub/eventdriven/vCodec.h
+++ b/libraries/include/iCub/eventdriven/vCodec.h
@@ -84,7 +84,7 @@ public:
 
     virtual event<> clone();
     virtual void encode(yarp::os::Bottle &b) const;
-    virtual void encode(std::vector<YARP_INT32> &b, unsigned int &pos) const;
+    virtual void encode(std::vector<std::int32_t> &b, unsigned int &pos) const;
     virtual bool decode(const yarp::os::Bottle &packet, int &pos);
     virtual void decode(int *&data);
     virtual yarp::os::Property getContent() const;
@@ -110,7 +110,7 @@ public:
 
     virtual event<> clone();
     virtual void encode(yarp::os::Bottle &b) const;
-    virtual void encode(std::vector<YARP_INT32> &b, unsigned int &pos) const;
+    virtual void encode(std::vector<std::int32_t> &b, unsigned int &pos) const;
     virtual bool decode(const yarp::os::Bottle &packet, int &pos);
     virtual void decode(int *&data);
     virtual yarp::os::Property getContent() const;
@@ -134,7 +134,7 @@ public:
 
     virtual event<> clone();
     virtual void encode(yarp::os::Bottle &b) const;
-    virtual void encode(std::vector<YARP_INT32> &b, unsigned int &pos) const;
+    virtual void encode(std::vector<std::int32_t> &b, unsigned int &pos) const;
     virtual bool decode(const yarp::os::Bottle &packet, int &pos);
     virtual void decode(int *&data);
     virtual yarp::os::Property getContent() const;
@@ -156,7 +156,7 @@ public:
 
     virtual event<> clone();
     virtual void encode(yarp::os::Bottle &b) const;
-    virtual void encode(std::vector<YARP_INT32> &b, unsigned int &pos) const;
+    virtual void encode(std::vector<std::int32_t> &b, unsigned int &pos) const;
     virtual bool decode(const yarp::os::Bottle &packet, int &pos);
     virtual void decode(int *&data);
     virtual yarp::os::Property getContent() const;
@@ -178,7 +178,7 @@ public:
 
     virtual event<> clone();
     virtual void encode(yarp::os::Bottle &b) const;
-    virtual void encode(std::vector<YARP_INT32> &b, unsigned int &pos) const;
+    virtual void encode(std::vector<std::int32_t> &b, unsigned int &pos) const;
     virtual bool decode(const yarp::os::Bottle &packet, int &pos);
     virtual void decode(int *&data);
     virtual yarp::os::Property getContent() const;

--- a/libraries/include/iCub/eventdriven/vPort.h
+++ b/libraries/include/iCub/eventdriven/vPort.h
@@ -33,14 +33,14 @@ class vGenPortInterface : public yarp::os::Portable {
 protected:
 
     //headers
-    std::vector<YARP_INT32> header1;
+    std::vector<std::int32_t> header1;
     std::string header2;
-    std::vector<YARP_INT32> header3;
+    std::vector<std::int32_t> header3;
 
     //data
     const char * datablock;
     unsigned int datalength; //<- set the number of bytes here
-    std::vector<YARP_INT32> internaldata;
+    std::vector<std::int32_t> internaldata;
     vQueue *read_q;
 
     //sizes
@@ -61,7 +61,7 @@ public:
         header3.push_back(BOTTLE_TAG_LIST|BOTTLE_TAG_INT); // bottle code + specialisation with ints
         header3.push_back(0); // <- set the number of ints here (e.g. 2 * #v's)
         elementINTS = 0;
-        elementBYTES = sizeof(YARP_INT32) * elementINTS;
+        elementBYTES = sizeof(std::int32_t) * elementINTS;
         read_q = 0;
     }
 
@@ -99,7 +99,7 @@ public:
         header2 = eventtype;            //set the string itself
 
         elementINTS = packetSize(eventtype);
-        elementBYTES = sizeof(YARP_INT32) * elementINTS;
+        elementBYTES = sizeof(std::int32_t) * elementINTS;
 
     }
 
@@ -133,7 +133,7 @@ public:
 
         if(ndata > internaldata.size())
             internaldata.resize(ndata);
-        if(!connection.expectBlock((const char *)internaldata.data(), sizeof(YARP_INT32) * ndata)) {
+        if(!connection.expectBlock((const char *)internaldata.data(), sizeof(std::int32_t) * ndata)) {
             yError() << "Could not read datablock";
             return false;
         }
@@ -164,10 +164,10 @@ public:
     virtual bool write(yarp::os::ConnectionWriter& connection) {
 
         connection.appendBlock((const char *)header1.data(),
-                                       header1.size() * sizeof(YARP_INT32));
+                                       header1.size() * sizeof(std::int32_t));
         connection.appendBlock(header2.c_str(), header1[3]);
         connection.appendBlock((const char *)header3.data(),
-                                       header3.size() * sizeof(YARP_INT32));
+                                       header3.size() * sizeof(std::int32_t));
         connection.appendBlock(datablock, datalength);
 
         return !connection.isError();
@@ -187,7 +187,7 @@ public:
         header1[3] = T::tag.size(); // length of string
         header2 = T::tag;
         elementINTS = packetSize(T::tag);
-        elementBYTES = sizeof(YARP_INT32) * elementINTS;
+        elementBYTES = sizeof(std::int32_t) * elementINTS;
     }
 
     /// \brief send an entire vQueue. The queue is encoded and allocated into a single contiguous memory space. Faster than a standard vBottle.
@@ -248,7 +248,7 @@ public:
 
         if(ndata > internaldata.size())
             internaldata.resize(ndata);
-        if(!connection.expectBlock((const char *)internaldata.data(), sizeof(YARP_INT32) * ndata)) {
+        if(!connection.expectBlock((const char *)internaldata.data(), sizeof(std::int32_t) * ndata)) {
             yError() << "Could not read datablock";
             return false;
         }

--- a/libraries/src/codecs/codec_AddressEvent.cpp
+++ b/libraries/src/codecs/codec_AddressEvent.cpp
@@ -61,7 +61,7 @@ void AddressEvent::encode(yarp::os::Bottle &b) const
 #endif
 }
 
-void AddressEvent::encode(std::vector<YARP_INT32> &b, unsigned int &pos) const
+void AddressEvent::encode(std::vector<std::int32_t> &b, unsigned int &pos) const
 {
     vEvent::encode(b, pos);
 #ifdef CODEC_128x128

--- a/libraries/src/codecs/codec_FlowEvent.cpp
+++ b/libraries/src/codecs/codec_FlowEvent.cpp
@@ -52,7 +52,7 @@ void FlowEvent::encode(yarp::os::Bottle &b) const
     b.addInt(*(int*)(&vy));
 }
 
-void FlowEvent::encode(std::vector<YARP_INT32> &b, unsigned int &pos) const
+void FlowEvent::encode(std::vector<std::int32_t> &b, unsigned int &pos) const
 {
     AddressEvent::encode(b, pos);
     b[pos++] = (*(int*)(&vx));

--- a/libraries/src/codecs/codec_GaussianAE.cpp
+++ b/libraries/src/codecs/codec_GaussianAE.cpp
@@ -55,7 +55,7 @@ void GaussianAE::encode(yarp::os::Bottle &b) const
     b.addInt(*(int*)(&sigxy));
 }
 
-void GaussianAE::encode(std::vector<YARP_INT32> &b, unsigned int &pos) const
+void GaussianAE::encode(std::vector<std::int32_t> &b, unsigned int &pos) const
 {
     LabelledAE::encode(b, pos);
     b[pos++] = (*(int*)(&sigx));

--- a/libraries/src/codecs/codec_LabelledAE.cpp
+++ b/libraries/src/codecs/codec_LabelledAE.cpp
@@ -49,7 +49,7 @@ void LabelledAE::encode(yarp::os::Bottle &b) const
     b.addInt(ID);
 }
 
-void LabelledAE::encode(std::vector<YARP_INT32> &b, unsigned int &pos) const
+void LabelledAE::encode(std::vector<std::int32_t> &b, unsigned int &pos) const
 {
     AddressEvent::encode(b, pos);
     b[pos++] = ID;

--- a/libraries/src/vCodec.cpp
+++ b/libraries/src/vCodec.cpp
@@ -62,7 +62,7 @@ bool temporalSortStraight(const event<> &e1, const event<> &e2) {
 bool temporalSortWrap(const event<> &e1, const event<> &e2)
 {
 
-    if(std::abs(e1->stamp - e2->stamp) > vtsHelper::max_stamp/2)
+    if(unsigned (std::abs(e1->stamp - e2->stamp)) > vtsHelper::max_stamp/2)
         return e1->stamp > e2->stamp;
     else
         return e2->stamp > e1->stamp;

--- a/src/applications/autosaccade/include/autoSaccade.h
+++ b/src/applications/autosaccade/include/autoSaccade.h
@@ -85,8 +85,8 @@ private:
     yarp::dev::PolyDriver mdriver;
     yarp::dev::PolyDriver gazeDriver;
     yarp::dev::IGazeControl *gazeControl;
-    yarp::dev::IPositionControl2 *ipos;
-    yarp::dev::IControlMode2     *imod;
+    yarp::dev::IPositionControl *ipos;
+    yarp::dev::IControlMode     *imod;
     int context0;
     std::string robotName;
 

--- a/src/applications/gazeDemo/include/vTrackToRobot.h
+++ b/src/applications/gazeDemo/include/vTrackToRobot.h
@@ -29,9 +29,9 @@
 #include <yarp/dev/CartesianControl.h>
 #include <yarp/dev/GazeControl.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/IControlMode2.h>
+#include <yarp/dev/IControlMode.h>
 #include <yarp/dev/IEncoders.h>
-#include <yarp/dev/IVelocityControl2.h>
+#include <yarp/dev/IVelocityControl.h>
 #include <deque>
 #include <vector>
 
@@ -157,7 +157,7 @@ protected:
 
     yarp::dev::PolyDriver         driver;
     yarp::dev::IEncoders         *ienc;
-    yarp::dev::IVelocityControl2 *ivel;
+    yarp::dev::IVelocityControl *ivel;
 
     int nAxes;
     std::vector<PID*> controllers;
@@ -221,7 +221,7 @@ public:
         controllers[5]->set(0.2, 0.0);
 
         //set velocity control mode
-        yarp::dev::IControlMode2 *imod;
+        yarp::dev::IControlMode *imod;
         if(!driver.view(imod)) {
             yError() << "Driver does not implement control mode";
             return false;

--- a/src/applications/gazeDemo/src/vTrackToRobot.cpp
+++ b/src/applications/gazeDemo/src/vTrackToRobot.cpp
@@ -342,12 +342,12 @@ bool vTrackToRobotModule::controlExternal(yarp::sig::Vector ltarget,
         yarp::os::Bottle &cartcoords = cartOutPort.prepare();
         cartcoords.clear();
         //    //add the XYZ position
-        cartcoords.add(tp[0]); cartcoords.add(tp[1]); cartcoords.add(tp[2]);
+        cartcoords.add(yarp::os::Value(tp[0])); cartcoords.add(yarp::os::Value(tp[1])); cartcoords.add(yarp::os::Value(tp[2]));
         //cartcoords.add(-1.0); cartcoords.add(0.0); cartcoords.add(-0.3);
         //    //add some buffer ints
-        cartcoords.add(0.5); cartcoords.add(pleft[0]); cartcoords.add(pleft[1]);
+        cartcoords.add(yarp::os::Value(0.5)); cartcoords.add(yarp::os::Value(pleft[0])); cartcoords.add(yarp::os::Value(pleft[1]));
         //    //flag that the object is detected
-        cartcoords.add(1.0);
+        cartcoords.add(yarp::os::Value(1.0));
 
         cartOutPort.write();
     }

--- a/src/applications/vergenceDemo/vergenceController/include/vergenceController.h
+++ b/src/applications/vergenceDemo/vergenceController/include/vergenceController.h
@@ -26,7 +26,7 @@
 #include <yarp/dev/IEncoders.h>
 #include <yarp/dev/IPositionControl.h>
 #include <yarp/dev/IVelocityControl.h>
-#include <yarp/dev/IControlMode2.h>
+#include <yarp/dev/IControlMode.h>
 #include "gaborfilters.h"
 
 class vVergenceManager : public yarp::os::BufferedPort<ev::vBottle>
@@ -59,7 +59,7 @@ private:
     yarp::dev::IEncoders *enccontrol;
     yarp::dev::IPositionControl *poscontrol;
     yarp::dev::IVelocityControl *velcontrol;
-    yarp::dev::IControlMode2 *controlmode;
+    yarp::dev::IControlMode *controlmode;
     std::vector<double> encs;
 //    double desiredvergence;
     double currvel;

--- a/src/hardwareio/chronocamGrabber/include/deviceController.h
+++ b/src/hardwareio/chronocamGrabber/include/deviceController.h
@@ -20,6 +20,7 @@
 #include <yarp/os/Bottle.h>
 
 #include <string>
+#include <iostream>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/processing/vCircle/src/vCircleModule.cpp
+++ b/src/processing/vCircle/src/vCircleModule.cpp
@@ -359,7 +359,7 @@ void vCircleReader::onRead(ev::vBottle &inBot)
     if(scopeOut.getOutputCount()) {
         yarp::os::Bottle &scopebottle = scopeOut.prepare();
         scopebottle.clear();
-        scopebottle.add(st.getCount() - pstampcounter);
+        scopebottle.add(yarp::os::Value(st.getCount() - pstampcounter));
         scopeOut.setEnvelope(st);
         scopeOut.write();
     }

--- a/src/processing/vFlow/src/vFlow.cpp
+++ b/src/processing/vFlow/src/vFlow.cpp
@@ -19,7 +19,6 @@
 #include "vFlow.h"
 #include <yarp/os/all.h>
 
-using yarp::math::operator *;
 using yarp::math::outerProduct;
 
 using namespace ev;

--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -84,8 +84,8 @@ bool vPreProcessModule::configure(yarp::os::ResourceFinder &rf)
 
 
     eventManager.initBasic(rf.check("name", yarp::os::Value("/vPreProcess")).asString(),
-                           rf.check("height", 240).asInt(),
-                           rf.check("width", 304).asInt(),
+                           rf.check("height", yarp::os::Value(240)).asInt(),
+                           rf.check("width", yarp::os::Value(304)).asInt(),
                            precheck, flipx, flipy, pepper, undistort, split);
 
     if(pepper) {


### PR DESCRIPTION
…ARP updates.

- Value constructor has been made explicit for numeric values
- YARP_INT_32 has been deprecated in favour of std::int32_t
- yarp::os::ConstString has been deprecated in favour of std::string
- Mathematical operators have been moved out of yarp::math namespace
- IPositionControl2, IVelocityControl2, IControlMode2 don't have the "2" suffix anymore