### PR TITLE
Fix/tutorials/aiko

### DIFF
--- a/documentation/1viewer.md
+++ b/documentation/1viewer.md
@@ -1,11 +1,11 @@
 # Testing your install with the viewer
 
-Visualise a stream of events from the cameras / from a pre-recorded sequence.
+Visualise a stream of events either from real hardware/camera or from a pre-recorded sequence.
 
 ## Description
 
 This application demonstrates how to visualise a stream of address events either from the cameras or from a pre-recorded sequence.
-The event stream is transmitted from the cameras (/zynqGrabber/AE:o) to the vPreProcess (/vPreProcess/AE:i), that removes salt-and-pepper noise from the event stream. The filtered stream (/vPreProcess/left:o and /vPreProcess/right:o) is sent to vFramer (/vFramer/left/AE:i), that converts it to a yarpview-able image. The "images" from left (/vFramer/left/image:o) and right camera (/vFramer/right/image:o) are then sent to the yarp viewers (/viewCh0 and /viewCh1).
+The event stream is transmitted from the cameras (`/zynqGrabber/AE:o`) to the vPreProcess (`/vPreProcess/AE:i`), that removes salt-and-pepper noise from the event stream. The filtered stream (`/vPreProcess/left:o` and `/vPreProcess/right:o`) is sent to vFramer (`/vFramer/left/AE:i`), that converts it to a yarpview-able image. The "images" from left (`/vFramer/left/image:o`) and right camera (`/vFramer/right/image:o`) are then sent to the yarp viewers (`/viewCh0` and `/viewCh1`).
 
 Here is a visualisation of the instantiated modules and connections.
 
@@ -13,46 +13,42 @@ Here is a visualisation of the instantiated modules and connections.
 
 ## How to run the application
 
-These are basic instructions for first time YARP users, assuming the comprehensive instructions have been followed.
+These are basic instructions for first time YARP users, assuming the [comprehensive instructions](full_installation.md) have been followed.
 
-* download the sample dataset from [here](https://doi.org/10.5281/zenodo.2556755) and unpack to a location of your choosing.
+* Download the sample dataset from [here](https://doi.org/10.5281/zenodo.2556755) and unpack to a location of your choosing.
 
-* set the yarp namespace
+* Set the yarp namespace:
+```bash
+yarp namespace /<yourname>
+```
+* Run a yarpserver:
+```bash
+yarpserver --write
+```
+### Using actual hardware/camera? Skip [ahead](#using-real-hardwarecamera). Using a dataset? Follow these instructions:
 
-> yarp namespace /<yourname>
-
-* run a yarpserver
-
-> yarpserver --write
-
-### Using actual hardware/camera? Skip ahead. Using a dataset? Follow these instructions:
-
-* (in a seperate terminal) run a yarpdataplayer
-
-> yarpdataplayer
-
-* in the yarpdataplayer gui, open the downloaded datsets (File->open) by pressing "Choose" on the upper-level folder (e.g. folder name: fasthandtrim)
-* the dataset should be open in the yarpdataplayer window with a "Port Name" of "/zynqGrabber/AE:o".
-* (in a separate terminal) run a yarpmanager
+* In a separate terminal, run a yarpdataplayer:
+```bash
+yarpdataplayer
+```
+* In the yarpdataplayer gui, open the downloaded datsets (File->open) by pressing "Choose" on the upper-level folder (e.g. folder name: fasthandtrim).
+* The dataset should be open in the yarpdataplayer window with a "Port Name" of `/zynqGrabber/AE:o`.
 
 ### Using real hardware/camera?
 
-You should have followed the instructions
-
-[to run install hardware and run zynqGrabber,](README.md)
-
-so your zynqGrabber should be running and a port `/zynqGrabber/AE:o` should be already open (check with `yarp name list`).
+* You should have followed the instructions [to run install hardware and run zynqGrabber,](README.md). 
+* So your zynqGrabber should be running and a port `/zynqGrabber/AE:o` should be already open (check with `yarp name list`).
 
 ### Okay - yarpdataplayer users, and hardware users back together here:
-
-> yarpmanager
-
-* the yarpmanager gui should be open.
-* on the entities tab (left) open the "Applications" folder - the vView application should be visible. Double click the `event-viewer-example` application to load it.
+* In a separate terminal, run a yarpmanager:
+```bash
+yarpmanager
+```
+* The yarpmanager gui should be open.
+* On the entities tab (left) open the "Applications" folder - the vView application should be visible. Double click the `event-viewer-example` application to load it.
 * If you do not have the `event-viewer-example` application, make sure you followed the installation steps correctly, and that your `YARP_DATA_DIRS` environment variable correctly points to the share folders in your install folder (`echo $YARP_DATA_DIRS`)
-* run all the modules in the `event-viewer-example` app by choosing "Run All" in the left-most vertical toolbar. All applications should become green.
-* if not all applications are green, it means the executable files could not be found on the `PATH`. Verfify your installation and your `PATH` environment variable (`echo $PATH`).
-* connect all yarp ports by choosing "Connect All" in the same toolbar. All connections should turn green.
-* press "Play" on the yarpdataplayer. The dataset should be visible in the yarpview windows (split into left and right cameras).
+* Run all the modules in the `event-viewer-example` app by choosing "Run All" in the left-most vertical toolbar. All applications should become green.
+* If not all applications are green, it means the executable files could not be found on the `PATH`. Verfify your installation and your `PATH` environment variable (`echo $PATH`).
+* Connect all yarp ports by choosing "Connect All" in the same toolbar. All connections should turn green.
+* Press "Play" on the yarpdataplayer. The dataset should be visible in the yarpview windows (split into left and right cameras).
 * To close all applications first "Disconnect All" and then "Close All" on the left-hand toolbar. GUI's are closed as per a normal window. The yarpserver can be closed using "ctrl+c" in the appropriate terminal.
-

--- a/documentation/1viewer.md
+++ b/documentation/1viewer.md
@@ -15,8 +15,9 @@ Here is a visualisation of the instantiated modules and connections.
 
 These are basic instructions for first time YARP users, assuming the [comprehensive instructions](full_installation.md) have been followed.
 
-* Download the sample dataset from [here](https://doi.org/10.5281/zenodo.2556755) and unpack to a location of your choosing.
+### Using actual hardware/camera? Skip [ahead](#using-real-hardwarecamera). Using a dataset? Follow these instructions:
 
+* Download the sample dataset from [here](https://doi.org/10.5281/zenodo.2556755) and unpack to a location of your choosing.
 * Set the yarp namespace:
 ```bash
 yarp namespace /<yourname>
@@ -25,8 +26,6 @@ yarp namespace /<yourname>
 ```bash
 yarpserver --write
 ```
-### Using actual hardware/camera? Skip [ahead](#using-real-hardwarecamera). Using a dataset? Follow these instructions:
-
 * In a separate terminal, run a yarpdataplayer:
 ```bash
 yarpdataplayer
@@ -37,7 +36,7 @@ yarpdataplayer
 ### Using real hardware/camera?
 
 * You should have followed the instructions [to run install hardware and run zynqGrabber](README.md). 
-* if everything went smoothly, your zynqGrabber should be running and a port `/zynqGrabber/AE:o` should be already open (check with `yarp name list`).
+* If everything went smoothly, your laptop should be connected to the `yarpserver` running on the ZCB, your zynqGrabber should be running and a port `/zynqGrabber/AE:o` should be already open (check with `yarp name list`).
 
 ### Okay - yarpdataplayer users, and hardware users back together here:
 * In a separate terminal, run a yarpmanager:

--- a/documentation/1viewer.md
+++ b/documentation/1viewer.md
@@ -51,4 +51,4 @@ yarpmanager
 * If not all applications are green, it means the executable files could not be found on the `PATH`. Verfify your installation and your `PATH` environment variable (`echo $PATH`).
 * Connect all yarp ports by choosing "Connect All" in the same toolbar. All connections should turn green.
 * Press "Play" on the yarpdataplayer. The dataset should be visible in the yarpview windows (split into left and right cameras).
-* To close all applications first "Disconnect All" and then "Close All" on the left-hand toolbar. GUI's are closed as per a normal window. The yarpserver can be closed using "ctrl+c" in the appropriate terminal.
+* To close all applications first "Disconnect All" and then "Close All" on the left-hand toolbar. GUI's are closed as per a normal window. The yarpserver can be closed using `ctrl+c` in the appropriate terminal.

--- a/documentation/1viewer.md
+++ b/documentation/1viewer.md
@@ -36,8 +36,8 @@ yarpdataplayer
 
 ### Using real hardware/camera?
 
-* You should have followed the instructions [to run install hardware and run zynqGrabber,](README.md). 
-* So your zynqGrabber should be running and a port `/zynqGrabber/AE:o` should be already open (check with `yarp name list`).
+* You should have followed the instructions [to run install hardware and run zynqGrabber](README.md). 
+* if everything went smoothly, your zynqGrabber should be running and a port `/zynqGrabber/AE:o` should be already open (check with `yarp name list`).
 
 ### Okay - yarpdataplayer users, and hardware users back together here:
 * In a separate terminal, run a yarpmanager:

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,58 +1,27 @@
 # Getting Started with `event-driven`
 
-You may have some hardware in front of you that you are unsure of how to use, if not, and you just need help with software, skip ahead. If you have any questions with the these instructions, please open a github issue on the `event-driven` repository page.
+You may have some hardware in front of you that you are unsure of how to use, if not, and you just need help with software, skip [ahead](#software). If you have any questions with the these instructions, please open a GitHub issue on the `event-driven`  repository page.
 
 ## Hardware
 
-Hardware could include sensors: ATIS, event-driven skin, cochlea, or IMU, as well as acquisition boards based on zynq chips: ZCB or z-turn. We'll assume the hardware is correctly connected and powered. However, you may need to
+* Hardware could include sensors (_e.g._ ATIS, event-driven skin, cochlea, or IMU), as well as acquisition boards based on zynq chips (_e.g._ ZCB or z-turn). We'll assume the hardware is correctly connected and powered. However, you may need to [set-up an sd-card for a ZCB or z-turn.](howtosetupSD.md)
 
-[set-up an sd-card for a ZCB or z-turn.](howtosetupSD.md)
+* If the system should be already ready-to-go, and you just need the board to start acquisition, you can follow these instructions to [connect to the ZCB or z-turn.](connect_to_zcb.md).
 
-If the system should be already ready-to-go, and you just need the board to start acquisition, you can follow these instructions to
+* Once you have a connection to the board, you need to [set-up the yarpserver](setup_yarpserver.md) to correctly communicate between your laptop and the board. 
 
-[connect to the ZCB or z-turn.](connect_to_zcb.md)
+* Finally you will need to [run `zynqGrabber`](zynqGrabber.md).
 
-Once you have a connection to the board, you need to
-
-[set-up the yarpserver](setup_yarpserver.md)
-
-to correctly communicate between your laptop and the board. Finally you will need to
-
-[run `zynqGrabber`](zynqGrabber.md)
-
-At this point, if you have checked your hardware is streaming events, you can start to read and process them, once your software is correctly installed on the laptop as well.
+* At this point, if you have checked your hardware is streaming events, you can start to read and process them, once your software is correctly installed on the laptop as well.
 
 ## Software
 
-The first step is to install the dependencies  - typically just YARP, is required but we reccommend YCM, as well as openCV for visualisation - and the `event-driven` library itself. The
+* The first step is to install the dependencies  - typically just [YARP](https://github.com/robotology/yarp), is required but we reccommend [YCM](https://github.com/robotology/ycm), as well as [OpenCV](https://opencv.org/) for visualisation - and the `event-driven` library itself. The [instructions for installation](full_installation.md) should be all you need to do to have a working environment. 
+* We suggest following the [getting started with visualising events](1viewer.md) tutorial to check everything is working, and to learn about the `yarpdataplayer`. If you can't get the tutorial working, double check everything is installed correctly, and if you can't find the problem, please open an issue on the `event-driven` repository page.
 
-[instructions for installation](full_installation.md)
+* Finally, once you are ready, you can [learn to write a basic processing module](example_module.md) which covers, reading and writing events, and understanding event timestamps. Your module probably needs a nice way of:
+    * [TODO: visualising your output](), and
+    * possibly needs to [TODO: correct for lens disortion or external other external calibration]()
+given you have [TOIMPROVE: calibrated your camera.](2calibration.md)
 
-should be all you need to do to have a working environment. We suggest following the
-
-[getting started with visualising events](1viewer.md)
-
-tutorial to check everything is working, and to learn about the `yarpdataplayer`. If you can't get the tutorial working, double check everything is installed correctly, and if you can't find the problem, please open an issue on the `event-driven` repository page.
-
-Finally, once you are ready, you can
-
-[learn to write a basic processing module](example_module.md)
-
-which covers, reading and writing events, and understanding event timestamps. Your module probably needs a nice way of
-
-[TODO: visualising your output]()
-
-and possibly needs to
-
-[TODO: correct for lens disortion or external other external calibration]()
-
-given you have
-
-[TOIMPROVE: calibrated your camera.](2calibration.md)
-
-You can also learn to
-
-[TODO: save and playback]()
-
-data for offline processing and experiment re-creation.
-
+* You can also learn to [TODO: save and playback]() data for offline processing and experiment re-creation.

--- a/documentation/datasets.md
+++ b/documentation/datasets.md
@@ -1,55 +1,50 @@
 # Datasets
 
-Event-driven datasets contain the stream of events captured from a single or stereo event cameras. Each dataset can be played using the _yarpdataplayer_. Once the dataset is loaded in the _yarpdataplayer_ the specified output port (default=/zynqGrabber/AE:o) is opened and can be connected to any event-driven processing module, the event-driven preprocessing module, or directly to the _vFramerLite_.
+Event-driven datasets contain the stream of events captured from a single or stereo event cameras. Each dataset can be played using the _yarpdataplayer_. Once the dataset is loaded in the _yarpdataplayer_, the specified output port (default=`/zynqGrabber/AE:o`) is opened and can be connected to any event-driven processing module, the event-driven pre-processing module (_vPreProcess_), or directly to the event-driven visualizer (_vFramerLite_).
 
-Each datasets may also contain, other sensors on the iCub (also re-playable with the _yarpdataplayer_) and ground truth measurements, given the task (e.g. ball locations, corner locations). Also included are Matlab scripts to generate the result figures as in the relevant papers.
+Each dataset may also contain:
 
-Datasets recorded with the DVS and ATIS have the following properties which must be set correctly, in the module parameters and the cmake options, to interpret the data:
-> [DVS]
-> width=128
-> height=128
-> VLIB_CODEC_TYPE=CODEC_128x128
-> VLIB_TIMER_BITS=24
-> VLIB_CLOCK_PERIOD_NS=128
+* other sensors on the iCub (also re-playable with the _yarpdataplayer_),
+* ground truth measurements, given the task (_e.g._ ball locations, corner locations), and 
+* Matlab scripts to generate the result figures as in the relevant papers.
 
-> [ATIS_20]
-> width=304
-> height=240
-> VLIB_CODEC_TYPE=CODEC_304x240_20
-> VLIB_TIMER_BITS=24
-> VLIB_CLOCK_PERIOD_NS=80
+Datasets recorded with the DVS and ATIS have the following properties which must be set correctly in the module parameters (_i.e._ width and height) and the CMake options (_i.e._ `VLIB_CODEC_TYPE`, `VLIB_TIMER_BITS` and `VLIB_CLOCK_PERIOD_NS`), to interpret the data:
 
-> [ATIS_24]
-> width=304
-> height=240
-> VLIB_CODEC_TYPE=CODEC_304x240_24
-> VLIB_TIMER_BITS=30
-> VLIB_CLOCK_PERIOD_NS=80
+| Sensor Type | width | height | `VLIB_CODEC_TYPE` | `VLIB_TIMER_BITS` | `VLIB_CLOCK_PERIOD_NS` |
+| ----------- | ----- | ------ | ----------------- | ----------------- | ---------------------- |
+| DVS         | 128   | 128    | CODEC_128x128     | 24                | 128                    |
 
-## Sample Dataset
+| Sensor Type | width | height | `VLIB_CODEC_TYPE` | `VLIB_TIMER_BITS` | `VLIB_CLOCK_PERIOD_NS` |
+| ----------- | ----- | ------ | ----------------- | ----------------- | ---------------------- |
+| ATIS_20     | 304   | 240    | CODEC_304x240_20  | 24                | 80                     |
 
+| Sensor Type | width | height | `VLIB_CODEC_TYPE` | `VLIB_TIMER_BITS` | `VLIB_CLOCK_PERIOD_NS` |
+| ----------- | ----- | ------ | ----------------- | ----------------- | ---------------------- |
+| ATIS_24     | 304   | 240    | CODEC_304x240_24  | 30                | 80                     |
+
+## Available Datasets
+
+### Sample Dataset
 * simple dataset to visualise
 * ATIS_24
 
 [download](https://doi.org/10.5281/zenodo.2556755)
 
-## Ball Detection and Tracking
-
+### Ball Detection and Tracking
 * 2 Datasets = hand-move, eye-move
 * DVS
 * ground truth supplied
 
 [download](https://figshare.com/s/0abd8f18312bec15b121)
 
-## Corner Detection
-
+### Corner Detection
 * 2 Datasets = checkboard (multiple different speeds and angles), naturalscene
 * DVS
 * ground truth supplied for naturalscene
 
 [download](https://figshare.com/s/0abd8f18312bec15b121)
 
-## VVV18-EVENTDRIVEN-DATASET
+### VVV18-EVENTDRIVEN-DATASET
 
 * 3 Datasets = 1, 2, 3 with different motions of the object and the robot
 * robot encoder positions for head and torso supplied, stereo ATIS output, stereo RGB camera supplied
@@ -58,7 +53,7 @@ Datasets recorded with the DVS and ATIS have the following properties which must
 
 [download](https://figshare.com/s/0abd8f18312bec15b121)
 
-## Parallel Visual Tracking
+### Parallel Visual Tracking
 
 * 10 datasets with moving circular target
 * contains ground truth and outputs of tracking algorithm run on the CPU and on the SpiNNAker

--- a/documentation/example_module.md
+++ b/documentation/example_module.md
@@ -1,55 +1,46 @@
 # Writing an example module for `event-driven`
 
-You are ready to write your own code that uses the tools in the `event-driven` library to process events. An example module is provided in [example_module](example_module) that you can use as the basis for writing a module that can be integrated into the `YARP` framework.
+You are ready to write your own code that uses the tools in the `event-driven` library to process events. An example module is provided in [example_module](example_module/README.md) that you can use as the basis for writing a module that can be integrated into the `YARP` framework.
 
 The module has the following functionality:
 
-* Reading a .ini file to load config options, and setting options via command line arguments.
-* Clean exit by capturing ctrl+c commands and allowing functions to close ports and clean memory.
+* Reading a `*.ini` file to load configuration options, and setting options via command line arguments.
+* Clean exit by capturing `ctrl+c` commands and allowing functions to close ports and clean memory.
 * Example `event-driven` ports for reading and writing events.
 * A synchronous thread, typically used to show a visualisation or status/debug messages at a readable rate.
 * An asynchronous thread, used to read events at sub-millisecond rates and perform processing as required.
-* An example cmake file for installing the generated binaries in the install location of `event-driven`, as well as installation of the configuration and application files in locations required by `YARP`.
+* An example CMake file for installing the generated binaries in the install location of `event-driven`, as well as installation of the configuration and application files in locations required by `YARP`.
 
 ## How to use the example-module
 
-First copy the example files to the new location of your project, e.g. the same folder that you have cloned `event-driven`. Assuming a \<path_to_projects\> directory:
-
-> cp -r \<path_to_projects\>/event-driven/documentation/example-module \<path_to_projects\>
+First, copy the example files to the new location of your project, _e.g._ the same folder where you have cloned `event-driven`.  Assuming a`<path_to_projects>` directory:
+```bash
+cp -r <path_to_projects>/event-driven/documentation/example-module <path_to_projects>
+```
 
 The project can be compiled with modifications:
+```bash
+cd <path_to_projects>/example-module
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
+make install -j4
+```
 
-> cd \<path_to_projects\>/example-module
-
-> mkdir build && cd build
-
-> cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
-
-> make install -j4
-
-However, some modifications should be made to personalise to project. The first step would be to change the folder, file and project name:
-
-> cd \<path_to_projects\>
-
-> mv example-module \<my-module-name\>
-
-> mv \<my-module-name\>/example-module.cpp \<my-module-name\>/<my-module-name\>.cpp
-
-> nano \<my-module-name\> CMakeLists.txt
-
-On line 5 change the project name to \<my-module-name\>
-
-> ctrl+o, ctrl+x
-
-> nano \<my-module-name\>/\<my-module-name\>.cpp
-
-On line 7, 19, and 124 change the class, constructor and declaration to \<my-module-name\>.
-
-> ctrl+o, ctrl+x
+However, some modifications should be made to personalise the project. The first step would be to change the folder, file and project name:
+```bash
+cd <path_to_projects>
+mv example-module <my-module-name>
+mv <my-module-name>/example-module.cpp <my-module-name>/<my-module-name>.cpp
+mv example-module.ini <my-module-name>.ini
+mv app_example-module.xml app_<my-module-name>.xml
+nano <my-module-name> CMakeLists.txt
+```
+On [line 5](https://github.com/robotology/event-driven/blob/99a1f941141b33266900e034d3e7789d55fd0d99/documentation/example-module/CMakeLists.txt#L5) change the project name to `<my-module-name>`, then save (`ctrl+o`) and exit (`ctrl+x`).
+```bash
+nano <my-module-name>/<my-module-name>.cpp
+```
+On line [7](https://github.com/robotology/event-driven/blob/99a1f941141b33266900e034d3e7789d55fd0d99/documentation/example-module/example-module.cpp#L7), [19](https://github.com/robotology/event-driven/blob/99a1f941141b33266900e034d3e7789d55fd0d99/documentation/example-module/example-module.cpp#L19), and [124](https://github.com/robotology/event-driven/blob/99a1f941141b33266900e034d3e7789d55fd0d99/documentation/example-module/example-module.cpp#L124) change the class, constructor and declaration to `<my-module-name>`, then save (`ctrl+o`) and exit (`ctrl+x`).
 
 The module should now be personalised to your processing task.
 
-If you like you can import the project into your favourite IDE to do so. E.g. for QTcreator *open a new project* by selecting `\<path_to_projects\>/\<my-module-name\>/CmakeLists.txt`. Select the kits `release` and `debug` modifying the build directory to `\<path_to_projects\>/\<my-module-name\>/build` and `\<path_to_projects\>/\<my-module-name\>/build-debug` respectively. You should now be able to edit, compile, run and debug the module from within QTcreator.
-
-
-
+If you like, you can import the project into your favourite IDE. To do so, _e.g._ for [QtCreator](https://www.qt.io/product) *open a new project* by selecting `<path_to_projects>/<my-module-name>/CmakeLists.txt`. Select the kits `release` and `debug` modifying the build directory to `<path_to_projects>/<my-module-name>/build` and `<path_to_projects>/<my-module-name>/build-debug` respectively. You should now be able to edit, compile, run and debug the module from within QtCreator.

--- a/documentation/full_installation.md
+++ b/documentation/full_installation.md
@@ -42,7 +42,7 @@ Finally, let's install event-driven`:
 ```bash
 cd ~/projects/event-driven
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=\~/projects/YCM/build -DYARP_DIR=\~/projects/yarp/build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=~/projects/YCM/build -DYARP_DIR=~/projects/yarp/build
 make install -j$(nproc)
 ```
 
@@ -56,6 +56,6 @@ cd ~/projects
 git clone https://github.com/robotology/icub-main.git
 cd icub-main
 mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=\~/projects/YCM/build -DYARP_DIR=\~/projects/yarp/build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=~/projects/YCM/build -DYARP_DIR=~/projects/yarp/build
 make install -j$(nproc)
 ```

--- a/documentation/full_installation.md
+++ b/documentation/full_installation.md
@@ -1,74 +1,61 @@
 # Comprehensive Installation
 
-We'll go through the recommended set-up of `event-driven` for a first time user of the `YARP` environment. The first step is to create a directory in which to install `YARP`, `event-driven` and the eventual modules you will write. For example
-
-> mkdir ~/yarp-install
-
-Secondly, we want to set up some environment variables that will make the install go smoother. Use your favourite text editor to open ~/.bashrc and add the following lines:
-
-* export INSTALL_DIR=~/yarp-install
-* export YARP_DATA_DIRS=$INSTALL_DIR/share/yarp:$INSTALL_DIR/share/event-driven
-* export PATH=$PATH:$INSTALL_DIR/bin
-
+We'll go through the recommended set-up of `event-driven` for a first time user of the `YARP` environment. 
+The first step is to create a directory in which to install `YARP`, `event-driven` and the eventual modules you will write. For example:
+```bash
+mkdir ~/yarp-install
+```
+Secondly, we want to set up some environment variables that will make the install go smoother. Use your favourite text editor to open `~/.bashrc` and add the following lines:
+```bash
+export INSTALL_DIR=~/yarp-install
+export YARP_DATA_DIRS=$INSTALL_DIR/share/yarp:$INSTALL_DIR/share/event-driven
+export PATH=$PATH:$INSTALL_DIR/bin
+```
 Next we want to get the required repositories. Change directory into one in which you want these projects, for example:
-
-> mkdir ~/projects && cd ~/projects
-
+```bash
+mkdir ~/projects && cd ~/projects
+```
 then,
-
-> git clone https://github.com/robotology/YCM.git
-
-> git clone https://github.com/robotology/yarp.git
-
-> git clone https://github.com/robotology/event-driven.git
-
-we are going to build the repositories in the above order too. However, first you might need some extra dependencies for `YARP`. One option is to go [here](http://wiki.icub.org/wiki/Linux:Installation_from_sources) and follow the _Getting all dependencies_ instructions (either installing dependencies yourself or adding to the `apt` path).
+```bash
+git clone https://github.com/robotology/YCM.git
+git clone https://github.com/robotology/yarp.git
+git clone https://github.com/robotology/event-driven.git
+```
+:warning: We are going to build the repositories in the above order too! However, first you might need some extra dependencies for `YARP`. One option is to go [here](http://wiki.icub.org/wiki/Linux:Installation_from_sources) and follow the _Getting all dependencies_ instructions (either installing dependencies yourself or adding to the `apt` path).
 
 Now you have dependencies, let's install `YCM`:
+```bash
+cd ~/projects/YCM
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
+make install -j$(nproc)
+```
 
-> cd ~/projects/YCM
-
-> mkdir build && cd build
-
-> cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
-
-> make install -j4
-
-then `YARP`
-
-> cd ~/projects/yarp
-
-> mkdir build && cd build
-
-> cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=~/projects/YCM/build
-
-> make install -j4
-
-then `event-driven`
-
-> cd ~/projects/event-driven
-
-> mkdir build && cd build
-
-> cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=\~/projects/YCM/build -DYARP_DIR=\~/projects/yarp/build
-
-> make install -j4
+Then let's install `YARP`:
+```bash
+cd ~/projects/yarp
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=~/projects/YCM/build
+make install -j$(nproc)
+```
+Finally, let's install event-driven`:
+```bash
+cd ~/projects/event-driven
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=\~/projects/YCM/build -DYARP_DIR=\~/projects/yarp/build
+make install -j$(nproc)
+```
 
 [Continue with the tutorials](README.md) to test your installation, or:
 
 ### Install icub-main (optional)
 
 `icub-main` is used if you are using the iCub robot and want to enable some of the `event-driven` modules that control the robot. To install `icub-main` do:
-
-> cd ~/projects
-
-> git clone https://github.com/robotology/icub-main.git
-
-> cd icub-main
-
-> mkdir build && cd build
-
-> cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=\~/projects/YCM/build -DYARP_DIR=\~/projects/yarp/build
-
-> make install -j4
-
+```bash
+cd ~/projects
+git clone https://github.com/robotology/icub-main.git
+cd icub-main
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DYCM_DIR=\~/projects/YCM/build -DYARP_DIR=\~/projects/yarp/build
+make install -j$(nproc)
+```


### PR DESCRIPTION
Minor fixes to `documentation/1viewer.md`, namely:
- substituting blockquotes with code blocks for codes,
- adding a few links (withing the same markdown file or to external ones),
- use code formatting for port names,
- move instructions regarding yarpmanager below section "Okay - ... back together here" since both hw and sw use this command.