### PR TITLE
adding replace flag for event_collapse

### DIFF
--- a/python/event_collapse/event_collapse.py
+++ b/python/event_collapse/event_collapse.py
@@ -43,15 +43,25 @@ def collapse(filename, min_bot_duration=2e-3):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Collapse events in bottles of duration at least min_bot_duration milliseconds')
     parser.add_argument('in_file', type=str, help='Input log file')
-    parser.add_argument('--min_bot_duration', '-m', default=2, type=int, nargs=1, help='Minimum duration of bottle into which events are collapsed')
+    parser.add_argument('--min_bot_duration', '-m', default=2.0, type=float, help='Minimum duration of bottle into which events are collapsed')
     parser.add_argument('--out_file', type=str, help='Output log file')
+    parser.add_argument('--replace', '-r', action='store_true', help='Copy output in place of original')
 
     args = parser.parse_args()
 
     if args.out_file is None:
-        args.out_file = os.path.join(os.path.dirname(args.in_file), 'data_collapsed.log')
+        if args.replace:
+            args.out_file = args.in_file
+            temp_in_file = os.path.join(os.path.dirname(args.in_file), 'data.orig.log')
+            if os.path.exists(temp_in_file):
+                print("Cannot replace file as it already exists: {}".format(temp_in_file))
+                exit(-1)
+            os.rename(args.in_file, temp_in_file)
+            args.in_file = temp_in_file
+        else:
+            args.out_file = os.path.join(os.path.dirname(args.in_file), 'data_collapsed.log')
 
-    text_out = '\n'.join([line for line in collapse(args.in_file, args.min_bot_duration * 1e-3)])
+    text_out = '\n'.join([line for line in collapse(args.in_file, min_bot_duration=(args.min_bot_duration * 1e-3))])
     with open(args.out_file, 'w') as of:
         of.write(text_out)
     print("Written to {}".format(args.out_file))


### PR DESCRIPTION
I like to "replace" the original data.log file with the new collapsed file (so dataplayer can immediately play it) but keep the original. The flag --replace or -r should do this if --out_file is not specified