### PR TITLE
Correct split flag in example application

### DIFF
--- a/documentation/example-module/app_example-module.xml
+++ b/documentation/example-module/app_example-module.xml
@@ -6,7 +6,7 @@
 
 <module>
     <name> vPreProcess </name>
-    <parameters>--flipx --flipy --split </parameters>
+    <parameters>--flipx --flipy --split_stereo </parameters>
     <node> localhost </node>
 </module>
 


### PR DESCRIPTION
corrected `split` flag of `vPreProcess` to `split_stereo` in xml app of viewer example in documentation. `split` flag doesn't exist anymore. Current default operation is to output processed events in single stereo channel `vPreProcess/AE:o` which is inconsistent with other connections of the application.