### PR TITLE
exposing Q matrix in vIPT library

### DIFF
--- a/lib/include/event-driven/vIPT.h
+++ b/lib/include/event-driven/vIPT.h
@@ -52,7 +52,7 @@ public:
     vIPT();
 
 
-    const cv::Mat getQ();
+    const cv::Mat& getQ();
     void setProjectedImageSize(int height, int width);
     bool configure(const std::string calibContext, const std::string calibFile, int size_scaler = 2);
     bool showMapProjections(double seconds = 0);

--- a/lib/include/event-driven/vIPT.h
+++ b/lib/include/event-driven/vIPT.h
@@ -35,6 +35,7 @@ private:
     cv::Mat stereo_rotation, stereo_translation;
     cv::Mat projection[2];
     cv::Mat rotation[2];
+    cv::Mat Q;
 
     cv::Mat point_forward_map[2];
     cv::Mat point_reverse_map[2];
@@ -50,6 +51,7 @@ public:
 
     vIPT();
 
+    const cv::Mat& getQ();
     void setProjectedImageSize(int height, int width);
     bool configure(const std::string calibContext, const std::string calibFile, int size_scaler = 2);
     bool showMapProjections(double seconds = 0);

--- a/lib/include/event-driven/vIPT.h
+++ b/lib/include/event-driven/vIPT.h
@@ -51,7 +51,7 @@ public:
 
     vIPT();
 
-    const cv::Mat& getQ();
+    const cv::Mat getQ();
     void setProjectedImageSize(int height, int width);
     bool configure(const std::string calibContext, const std::string calibFile, int size_scaler = 2);
     bool showMapProjections(double seconds = 0);

--- a/lib/src/vIPT.cpp
+++ b/lib/src/vIPT.cpp
@@ -157,7 +157,7 @@ void vIPT::setProjectedImageSize(int height, int width)
     size_shared.width = width;
 }
 
-const cv::Mat& vIPT::getQ(){
+const cv::Mat vIPT::getQ(){
     return Q;
 }
 

--- a/lib/src/vIPT.cpp
+++ b/lib/src/vIPT.cpp
@@ -31,7 +31,6 @@ namespace ev {
 vIPT::vIPT()
 {
     size_shared = Size(0, 0);
-    Q = cv::Mat(4, 4, CV_64FC1);
 }
 
 bool vIPT::importIntrinsics(int cam, Bottle &parameters)
@@ -109,13 +108,13 @@ bool vIPT::computeForwardReverseMaps(int cam)
     if(mat_reverse_map[cam].empty()) {
         yError() << "Camera Calibration failed";
         std::cout << "Camera Matrix: " << std::endl << cam_matrix[cam]
-                     << std::endl << std::endl;
+                  << std::endl << std::endl;
         std::cout << "Distortion Coefficients: " << std::endl << dist_coeff[cam]
-                     << std::endl << std::endl;
+                  << std::endl << std::endl;
         std::cout << "Rotation Matrix: " << std::endl << rotation[cam]
-                     << std::endl << std::endl;
+                  << std::endl << std::endl;
         std::cout << "Projection Matrix: " << std::endl << projection[cam]
-                     << std::endl << std::endl;
+                  << std::endl << std::endl;
         std::cout << "Size of Projection Space: " << size_shared << std::endl;
         return false;
     }
@@ -158,7 +157,7 @@ void vIPT::setProjectedImageSize(int height, int width)
 }
 
 
-const cv::Mat vIPT::getQ(){
+const cv::Mat& vIPT::getQ(){
     return Q;
 }
 
@@ -190,6 +189,7 @@ bool vIPT::configure(const string calibContext, const string calibFile, int size
         yInfo() << "Camera 0 and Camera 1 is and Extrinsic parameters exist - creating rectified transforms";
         //compute stereo + rectification
 
+        Q = cv::Mat(4, 4, CV_64FC1);
 
         //Computing homographies for left and right image
         cv::stereoRectify(cam_matrix[0], dist_coeff[0], cam_matrix[1],

--- a/lib/src/vIPT.cpp
+++ b/lib/src/vIPT.cpp
@@ -31,6 +31,7 @@ namespace ev {
 vIPT::vIPT()
 {
     size_shared = Size(0, 0);
+    Q = cv::Mat(4, 4, CV_64FC1);
 }
 
 bool vIPT::importIntrinsics(int cam, Bottle &parameters)
@@ -108,13 +109,13 @@ bool vIPT::computeForwardReverseMaps(int cam)
     if(mat_reverse_map[cam].empty()) {
         yError() << "Camera Calibration failed";
         std::cout << "Camera Matrix: " << std::endl << cam_matrix[cam]
-                  << std::endl << std::endl;
+                     << std::endl << std::endl;
         std::cout << "Distortion Coefficients: " << std::endl << dist_coeff[cam]
-                  << std::endl << std::endl;
+                     << std::endl << std::endl;
         std::cout << "Rotation Matrix: " << std::endl << rotation[cam]
-                  << std::endl << std::endl;
+                     << std::endl << std::endl;
         std::cout << "Projection Matrix: " << std::endl << projection[cam]
-                  << std::endl << std::endl;
+                     << std::endl << std::endl;
         std::cout << "Size of Projection Space: " << size_shared << std::endl;
         return false;
     }
@@ -156,6 +157,10 @@ void vIPT::setProjectedImageSize(int height, int width)
     size_shared.width = width;
 }
 
+const cv::Mat& vIPT::getQ(){
+    return Q;
+}
+
 bool vIPT::configure(const string calibContext, const string calibFile, int size_scaler)
 
 {
@@ -184,7 +189,7 @@ bool vIPT::configure(const string calibContext, const string calibFile, int size
         yInfo() << "Camera 0 and Camera 1 is and Extrinsic parameters exist - creating rectified transforms";
         //compute stereo + rectification
 
-        cv::Mat Q(4, 4, CV_64FC1);
+
         //Computing homographies for left and right image
         cv::stereoRectify(cam_matrix[0], dist_coeff[0], cam_matrix[1],
                 dist_coeff[1], size_cam[0], stereo_rotation, stereo_translation,

--- a/src/applications/calibrate/app_vCalib.xml.template
+++ b/src/applications/calibrate/app_vCalib.xml.template
@@ -12,7 +12,7 @@
 
 <module>
     <name> vPreProcess </name>
-    <parameters> --flipx --flipy --pepper false --split </parameters>
+    <parameters> --flipx --flipy --pepper false --split_stereo </parameters>
     <node> icub23 </node>
 </module>
 

--- a/src/applications/calibrate/app_vCalibChess.xml.template
+++ b/src/applications/calibrate/app_vCalibChess.xml.template
@@ -12,7 +12,7 @@
 
 <module>
     <name> vPreProcess</name>
-    <parameters> --split --undistort false --flipx --flipy --filter_temporal false --filter_spatial true </parameters>
+    <parameters> --split_stereo --undistort false --flipx --flipy --filter_temporal false --filter_spatial true </parameters>
     <node> localhost </node>
 </module>
 

--- a/src/applications/gazeDemo/app_vGazeDemo.xml.template
+++ b/src/applications/gazeDemo/app_vGazeDemo.xml.template
@@ -9,7 +9,7 @@
 
 <module>
     <name> vPreProcess </name>
-    <parameters> --flipy --flipx --split --undistort false --temporalSize 250000 </parameters>
+    <parameters> --flipy --flipx --split_stereo --undistort false --temporalSize 250000 </parameters>
     <node> icub23 </node>
 </module>
 

--- a/src/applications/view/app_event-viewer-example.xml
+++ b/src/applications/view/app_event-viewer-example.xml
@@ -6,7 +6,7 @@
 
 <module>
     <name> vPreProcess </name>
-    <parameters>--flipx --flipy --split </parameters>
+    <parameters>--flipx --flipy --split_stereo </parameters>
     <node> localhost </node>
 </module>
 

--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -87,7 +87,7 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
     bool filter_temporal = rf.check("filter_temporal") &&
                            rf.check("filter_temporal", Value(true)).asBool();
     undistort = rf.check("undistort") &&
-            rf.check("undistort", Value(true)).asBool();
+                rf.check("undistort", Value(true)).asBool();
     flipx = rf.check("flipx") &&
             rf.check("flipx", Value(true)).asBool();
     flipy = rf.check("flipy") &&
@@ -135,7 +135,7 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
                          Value(0.05)).asDouble() * vtsHelper::vtsscaler,
                 rf.check("sf_size",
                          Value(1)).asInt());
-    filter_right.use_spatial_filter(
+        filter_right.use_spatial_filter(
                 rf.check("sf_time",
                          Value(0.05)).asDouble() * vtsHelper::vtsscaler,
                 rf.check("sf_size",
@@ -146,7 +146,7 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
         filter_left.use_temporal_filter(
                 rf.check("tf_time",
                          Value(0.1)).asDouble() * vtsHelper::vtsscaler);
-    filter_right.use_temporal_filter(
+        filter_right.use_temporal_filter(
                 rf.check("tf_time",
                          Value(0.1)).asDouble() * vtsHelper::vtsscaler);
     }

--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -83,25 +83,25 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
     res.width = rf.check("width", Value(304)).asInt();
 
     bool filter_spatial = rf.check("filter_spatial") &&
-                          rf.check("filter_spatial", Value(true)).asBool();
+            rf.check("filter_spatial", Value(true)).asBool();
     bool filter_temporal = rf.check("filter_temporal") &&
-                           rf.check("filter_temporal", Value(true)).asBool();
+            rf.check("filter_temporal", Value(true)).asBool();
     undistort = rf.check("undistort") &&
-                rf.check("undistort", Value(true)).asBool();
+            rf.check("undistort", Value(true)).asBool();
     flipx = rf.check("flipx") &&
             rf.check("flipx", Value(true)).asBool();
     flipy = rf.check("flipy") &&
             rf.check("flipy", Value(true)).asBool();
     precheck = rf.check("precheck") &&
-               rf.check("precheck", Value(true)).asBool();
+            rf.check("precheck", Value(true)).asBool();
     split_stereo = rf.check("split_stereo") &&
-                   rf.check("split_stereo", Value(true)).asBool();
+            rf.check("split_stereo", Value(true)).asBool();
     split_polarities = rf.check("split_polarities") &&
-                       rf.check("split_polarities", Value(true)).asBool();
+            rf.check("split_polarities", Value(true)).asBool();
     combined_stereo = rf.check("combined_stereo") &&
-                      rf.check("combined_stereo", Value(true)).asBool();
+            rf.check("combined_stereo", Value(true)).asBool();
     use_local_stamp = rf.check("local_stamp") &&
-                      rf.check("local_stamp", Value(true)).asBool();
+            rf.check("local_stamp", Value(true)).asBool();
 
     if(!split_stereo) combined_stereo = true;
 
@@ -131,24 +131,24 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
     }
     if(filter_spatial) {
         filter_left.use_spatial_filter(
-                rf.check("sf_time",
-                         Value(0.05)).asDouble() * vtsHelper::vtsscaler,
-                rf.check("sf_size",
-                         Value(1)).asInt());
+                    rf.check("sf_time",
+                             Value(0.05)).asDouble() * vtsHelper::vtsscaler,
+                    rf.check("sf_size",
+                             Value(1)).asInt());
         filter_right.use_spatial_filter(
-                rf.check("sf_time",
-                         Value(0.05)).asDouble() * vtsHelper::vtsscaler,
-                rf.check("sf_size",
-                         Value(1)).asInt());
+                    rf.check("sf_time",
+                             Value(0.05)).asDouble() * vtsHelper::vtsscaler,
+                    rf.check("sf_size",
+                             Value(1)).asInt());
     }
 
     if(filter_temporal) {
         filter_left.use_temporal_filter(
-                rf.check("tf_time",
-                         Value(0.1)).asDouble() * vtsHelper::vtsscaler);
+                    rf.check("tf_time",
+                             Value(0.1)).asDouble() * vtsHelper::vtsscaler);
         filter_right.use_temporal_filter(
-                rf.check("tf_time",
-                         Value(0.1)).asDouble() * vtsHelper::vtsscaler);
+                    rf.check("tf_time",
+                             Value(0.1)).asDouble() * vtsHelper::vtsscaler);
     }
 
     if(undistort) {
@@ -250,15 +250,15 @@ bool vPreProcess::updateModule() {
     auto max_d = *bounds.second * 1000;
 
     auto mean_d = 1000 *
-                  std::accumulate(delays.begin(), delays.end(), 0.0) / delays.size();
+            std::accumulate(delays.begin(), delays.end(), 0.0) / delays.size();
     delays.clear();
 
     auto meanr = vtsHelper::vtsscaler *
-                 std::accumulate(rates.begin(), rates.end(), 0.0) / rates.size();
+            std::accumulate(rates.begin(), rates.end(), 0.0) / rates.size();
     rates.clear();
 
     auto meani = 1000 *
-                 std::accumulate(intervals.begin(), intervals.end(), 0.0) / intervals.size();
+            std::accumulate(intervals.begin(), intervals.end(), 0.0) / intervals.size();
     intervals.clear();
 
     //yInfo() << mind << meand << maxd << " : min | mean | max";

--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -83,9 +83,9 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
     res.width = rf.check("width", Value(304)).asInt();
 
     bool filter_spatial = rf.check("filter_spatial") &&
-            rf.check("filter_spatial", Value(true)).asBool();
+                          rf.check("filter_spatial", Value(true)).asBool();
     bool filter_temporal = rf.check("filter_temporal") &&
-            rf.check("filter_temporal", Value(true)).asBool();
+                           rf.check("filter_temporal", Value(true)).asBool();
     undistort = rf.check("undistort") &&
             rf.check("undistort", Value(true)).asBool();
     flipx = rf.check("flipx") &&
@@ -93,15 +93,15 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
     flipy = rf.check("flipy") &&
             rf.check("flipy", Value(true)).asBool();
     precheck = rf.check("precheck") &&
-            rf.check("precheck", Value(true)).asBool();
+               rf.check("precheck", Value(true)).asBool();
     split_stereo = rf.check("split_stereo") &&
-            rf.check("split_stereo", Value(true)).asBool();
+                   rf.check("split_stereo", Value(true)).asBool();
     split_polarities = rf.check("split_polarities") &&
-            rf.check("split_polarities", Value(true)).asBool();
+                       rf.check("split_polarities", Value(true)).asBool();
     combined_stereo = rf.check("combined_stereo") &&
-            rf.check("combined_stereo", Value(true)).asBool();
+                      rf.check("combined_stereo", Value(true)).asBool();
     use_local_stamp = rf.check("local_stamp") &&
-            rf.check("local_stamp", Value(true)).asBool();
+                      rf.check("local_stamp", Value(true)).asBool();
 
     if(!split_stereo) combined_stereo = true;
 
@@ -131,24 +131,24 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
     }
     if(filter_spatial) {
         filter_left.use_spatial_filter(
-                    rf.check("sf_time",
-                             Value(0.05)).asDouble() * vtsHelper::vtsscaler,
-                    rf.check("sf_size",
-                             Value(1)).asInt());
-        filter_right.use_spatial_filter(
-                    rf.check("sf_time",
-                             Value(0.05)).asDouble() * vtsHelper::vtsscaler,
-                    rf.check("sf_size",
-                             Value(1)).asInt());
+                rf.check("sf_time",
+                         Value(0.05)).asDouble() * vtsHelper::vtsscaler,
+                rf.check("sf_size",
+                         Value(1)).asInt());
+    filter_right.use_spatial_filter(
+                rf.check("sf_time",
+                         Value(0.05)).asDouble() * vtsHelper::vtsscaler,
+                rf.check("sf_size",
+                         Value(1)).asInt());
     }
 
     if(filter_temporal) {
         filter_left.use_temporal_filter(
-                    rf.check("tf_time",
-                             Value(0.1)).asDouble() * vtsHelper::vtsscaler);
-        filter_right.use_temporal_filter(
-                    rf.check("tf_time",
-                             Value(0.1)).asDouble() * vtsHelper::vtsscaler);
+                rf.check("tf_time",
+                         Value(0.1)).asDouble() * vtsHelper::vtsscaler);
+    filter_right.use_temporal_filter(
+                rf.check("tf_time",
+                         Value(0.1)).asDouble() * vtsHelper::vtsscaler);
     }
 
     if(undistort) {
@@ -250,15 +250,15 @@ bool vPreProcess::updateModule() {
     auto max_d = *bounds.second * 1000;
 
     auto mean_d = 1000 *
-            std::accumulate(delays.begin(), delays.end(), 0.0) / delays.size();
+                  std::accumulate(delays.begin(), delays.end(), 0.0) / delays.size();
     delays.clear();
 
     auto meanr = vtsHelper::vtsscaler *
-            std::accumulate(rates.begin(), rates.end(), 0.0) / rates.size();
+                 std::accumulate(rates.begin(), rates.end(), 0.0) / rates.size();
     rates.clear();
 
     auto meani = 1000 *
-            std::accumulate(intervals.begin(), intervals.end(), 0.0) / intervals.size();
+                 std::accumulate(intervals.begin(), intervals.end(), 0.0) / intervals.size();
     intervals.clear();
 
     //yInfo() << mind << meand << maxd << " : min | mean | max";


### PR DESCRIPTION
- Added `cv::Mat Q` as a private data-member of `vIPT` and public `getQ()` method to access it
- fixed `split_stereo` flags for some xml app templates (might be inconsequential because of being outdated)