### PR TITLE
fix order of convertToSI() bug

### DIFF
--- a/lib/src/codecs/codec_IMUEvent.cpp
+++ b/lib/src/codecs/codec_IMUEvent.cpp
@@ -98,25 +98,22 @@ double IMUevent::convertToSI(int value, int index)
 
     switch(index) {
     case(ACC_X):
-        return (value * (9.80665 / 16384.0)+ax_bias)*ax_gain;
-    case(ACC_Y):
-        return -(value * (9.80665 / 16384.0)+ay_bias)*ay_gain;
     case(ACC_Z):
         return (value * (9.80665 / 16384.0)+az_bias)*az_gain;
+    case(ACC_Y):
+        return -(value * (9.80665 / 16384.0)+ay_bias)*ay_gain;
     case(GYR_X):
-        return (value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
-    case(GYR_Y):
-        return -(value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
     case(GYR_Z):
         return value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0));
+    case(GYR_Y):
+        return -(value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
     case(TEMP):
         return (value / 333.87) + (273.15 + 21.0);
     case(MAG_X):
+    case(MAG_Z):
         return value * (/*10e6 **/ 4900.0 / 16384.0);
     case(MAG_Y):
         return -(value * (/*10e6 **/ 4900.0 / 16384.0));
-    case(MAG_Z):
-        return value * (/*10e6 **/ 4900.0 / 16384.0);
     }
 
     return -1;

--- a/lib/src/codecs/codec_IMUEvent.cpp
+++ b/lib/src/codecs/codec_IMUEvent.cpp
@@ -88,20 +88,21 @@ std::string IMUevent::getType() const
 
 double IMUevent::convertToSI(int value, int index)
 {
-    static constexpr double ax_bias = 0.21;
     static constexpr double ay_bias = 0.12;
+    static constexpr double ax_bias = 0.21;
     static constexpr double az_bias = 0.06;
-    static constexpr double ax_gain = 9.80665/9.84;
     static constexpr double ay_gain = 9.80665/9.83;
+    static constexpr double ax_gain = 9.80665/9.84;
     static constexpr double az_gain = 9.80665/9.95;
 
 
     switch(index) {
     case(ACC_X):
-    case(ACC_Z):
-        return (value * (9.80665 / 16384.0)+az_bias)*az_gain;
+        return (value * (9.80665 / 16384.0)+ax_bias)*ax_gain;
     case(ACC_Y):
         return -(value * (9.80665 / 16384.0)+ay_bias)*ay_gain;
+    case(ACC_Z):
+        return (value * (9.80665 / 16384.0)+az_bias)*az_gain;
     case(GYR_X):
     case(GYR_Z):
         return value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0));

--- a/lib/src/codecs/codec_IMUEvent.cpp
+++ b/lib/src/codecs/codec_IMUEvent.cpp
@@ -86,13 +86,13 @@ std::string IMUevent::getType() const
     return IMUevent::tag;
 }
 
-double IMUevent::convertToSI(int index, int value)
+double IMUevent::convertToSI(int value, int index)
 {
-    static constexpr double ay_bias = 0.12;
     static constexpr double ax_bias = 0.21;
+    static constexpr double ay_bias = 0.12;
     static constexpr double az_bias = 0.06;
-    static constexpr double ay_gain = 9.80665/9.83;
     static constexpr double ax_gain = 9.80665/9.84;
+    static constexpr double ay_gain = 9.80665/9.83;
     static constexpr double az_gain = 9.80665/9.95;
 
 
@@ -100,21 +100,21 @@ double IMUevent::convertToSI(int index, int value)
     case(ACC_X):
         return (value * (9.80665 / 16384.0)+ax_bias)*ax_gain;
     case(ACC_Y):
-        return (value * -(9.80665 / 16384.0)+ay_bias)*ay_gain;
+        return -(value * (9.80665 / 16384.0)+ay_bias)*ay_gain;
     case(ACC_Z):
         return (value * (9.80665 / 16384.0)+az_bias)*az_gain;
     case(GYR_X):
+    case(GYR_Y):
+        //return -(value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
     case(GYR_Z):
         return value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0));
-    case(GYR_Y):
-        return value * -(250.0 * M_PI / (2.0 * 180.0 * 16384.0));
     case(TEMP):
         return (value / 333.87) + (273.15 + 21.0);
     case(MAG_X):
     case(MAG_Z):
         return value * (/*10e6 **/ 4900.0 / 16384.0);
     case(MAG_Y):
-        return value * -(/*10e6 **/ 4900.0 / 16384.0);
+        return -(value * (/*10e6 **/ 4900.0 / 16384.0));
     }
 
     return -1;

--- a/lib/src/codecs/codec_IMUEvent.cpp
+++ b/lib/src/codecs/codec_IMUEvent.cpp
@@ -104,17 +104,19 @@ double IMUevent::convertToSI(int value, int index)
     case(ACC_Z):
         return (value * (9.80665 / 16384.0)+az_bias)*az_gain;
     case(GYR_X):
+        return (value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
     case(GYR_Y):
-        //return -(value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
+        return -(value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0)));
     case(GYR_Z):
         return value * (250.0 * M_PI / (2.0 * 180.0 * 16384.0));
     case(TEMP):
         return (value / 333.87) + (273.15 + 21.0);
     case(MAG_X):
-    case(MAG_Z):
         return value * (/*10e6 **/ 4900.0 / 16384.0);
     case(MAG_Y):
         return -(value * (/*10e6 **/ 4900.0 / 16384.0));
+    case(MAG_Z):
+        return value * (/*10e6 **/ 4900.0 / 16384.0);
     }
 
     return -1;


### PR DESCRIPTION
fix parameters order in convertToSI()
remove gyro_Y, which was not present on old code (please review)