### PR TITLE
added hexviewer v0.1

### DIFF
--- a/src/processing/CMakeLists.txt
+++ b/src/processing/CMakeLists.txt
@@ -6,6 +6,7 @@ option(ENABLE_vFlow "Build optical flow module" OFF)
 option(ENABLE_vSkinInterface "Build basic skin pre-processing" OFF)
 option(ENABLE_vCorner "Build corner detection module" OFF)
 option(ENABLE_DualCamTransform "Build Frame->ATIS geometric transform" OFF)
+option(ENABLE_vHexviewer "Enable a hexadecimal raw-event viewer" ON)
 
 if(OpenCV_FOUND)
     if(ENABLE_vFramer)
@@ -55,4 +56,6 @@ if(ENABLE_DualCamTransform)
     add_subdirectory(DualCamTransform)
 endif()
 
-
+if(ENABLE_vHexviewer)
+    add_subdirectory(vHexviewer)
+endif()

--- a/src/processing/vHexviewer/CMakeLists.txt
+++ b/src/processing/vHexviewer/CMakeLists.txt
@@ -1,0 +1,17 @@
+project(vHexviewer)
+
+add_executable(${PROJECT_NAME} vHexviewer.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE YARP::YARP_OS
+                                              YARP::YARP_init
+                                              ev::${EVENTDRIVEN_LIBRARY})
+
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+yarp_install(FILES ${PROJECT_NAME}.ini
+             DESTINATION ${EVENT-DRIVEN_CONTEXTS_INSTALL_DIR}/${CONTEXT_DIR})
+
+if(ADD_DOCS_TO_IDE)
+  add_custom_target(${PROJECT_NAME}_docs SOURCES ${PROJECT_NAME}.ini ${PROJECT_NAME}.xml)
+endif(ADD_DOCS_TO_IDE)
+

--- a/src/processing/vHexviewer/vHexviewer.cpp
+++ b/src/processing/vHexviewer/vHexviewer.cpp
@@ -147,7 +147,7 @@ int main(int argc, char * argv[])
     yarp::os::Network yarp;
     if(!yarp.checkNetwork(2)) {
         std::cout << "Could not connect to YARP" << std::endl;
-        return false;
+        return -1;
     }
 
     /* prepare and configure the resource finder */

--- a/src/processing/vHexviewer/vHexviewer.cpp
+++ b/src/processing/vHexviewer/vHexviewer.cpp
@@ -1,0 +1,125 @@
+
+#include <yarp/os/all.h>
+#include <event-driven/all.h>
+#include <iomanip>
+#include <sstream>
+
+using namespace ev;
+using namespace yarp::os;
+using std::vector;
+
+class hexViewer : public RFModule, public Thread {
+
+private:
+
+    vReadPort< vector<AE> > input_port;
+    int mask;
+    int cols;
+
+public:
+
+    hexViewer() {}
+
+    virtual bool configure(yarp::os::ResourceFinder& rf)
+    {
+        //set the module name used to name ports
+        setName((rf.check("name", Value("/vHexviewer")).asString()).c_str());
+
+        //open io ports
+        if(!input_port.open(getName() + "/AE:i")) {
+            yError() << "Could not open input port";
+            return false;
+        }
+
+        cols = rf.check("cols", Value(4)).asInt();
+        mask = rf.check("mask", Value(0x00000000)).asInt();
+
+        std::stringstream ss;
+        ss << std::hex << std::setfill('0') << std::internal << std::uppercase
+           << "0x" << std::setw(8) << mask;
+
+        if(mask)
+            yInfo() << "Showing only events with bits: " << ss.str();
+
+        //start the asynchronous and synchronous threads
+        return Thread::start();
+    }
+
+    virtual double getPeriod()
+    {
+        return 1.0; //period of synchrnous thread
+    }
+
+    bool interruptModule()
+    {
+        //if the module is asked to stop ask the asynchrnous thread to stop
+        return Thread::stop();
+    }
+
+    void onStop()
+    {
+        //when the asynchrnous thread is asked to stop, close ports and do
+        //other clean up
+        input_port.close();
+    }
+
+    //synchronous thread
+    virtual bool updateModule()
+    {
+        return Thread::isRunning();
+    }
+
+    //asynchronous thread run forever
+    void run()
+    {
+        Stamp yarpstamp;
+        std::cout << std::hex << std::setfill('0') << std::internal << std::uppercase;
+        int coli = 0;
+
+        while(!Thread::isStopping()) {
+
+            int qs = input_port.queryunprocessed() - 1;
+            if(qs < 1) qs = 1;
+
+            for(int i = 0; i < qs; i++)
+            {
+                const vector<AE> * q = input_port.read(yarpstamp);
+                if(!q) return;
+                for(auto &v : (*q))
+                {
+                    if((v._coded_data & mask) == mask) {
+                        if(coli++ % cols == 0) std::cout << std::endl;
+                        std::cout << "0x" << std::setw(8) << v._coded_data << " ";
+                    }
+                }
+            }
+
+            if(coli) {
+                coli = 0;
+                std::cout << std::endl << "==";
+                std::cout.flush();
+            }
+        }
+    }
+};
+
+int main(int argc, char * argv[])
+{
+    /* initialize yarp network */
+    yarp::os::Network yarp;
+    if(!yarp.checkNetwork(2)) {
+        std::cout << "Could not connect to YARP" << std::endl;
+        return false;
+    }
+
+    /* prepare and configure the resource finder */
+    yarp::os::ResourceFinder rf;
+    rf.setVerbose( false );
+    rf.setDefaultContext( "event-driven" );
+    rf.setDefaultConfigFile( "vHexviewer.ini" );
+    rf.configure( argc, argv );
+
+    /* create the module */
+    hexViewer instance;
+    return instance.runModule(rf);
+}

--- a/src/processing/vHexviewer/vHexviewer.cpp
+++ b/src/processing/vHexviewer/vHexviewer.cpp
@@ -33,40 +33,50 @@ public:
         }
 
         cols = rf.check("cols", Value(4)).asInt();
-        std::string maskstring = rf.check("mask", Value("")).asString();
+        std::stringstream ss; ss.str("");
+
         bits_to_check = 0; mask = 0;
-
-        //navigate through
-        int bit = 0;
-        for(std::string::const_reverse_iterator c = maskstring.rbegin();
-            c != maskstring.rend(); c++, bit++) {
-
-            if(*c == '1') {
-                mask |= (1 << bit);
-                bits_to_check |= (1 << bit);
-            } else if(*c == '0') {
-                bits_to_check |= (1 << bit);
+        if(rf.check("mask")) {
+            std::string maskstring = rf.check("mask", Value("x")).asString();
+            if(maskstring.empty()) {
+                ss.str(""); ss << rf.find("mask").asInt();
+                maskstring = ss.str();
             }
 
-        }
+            //navigate through
+            int bit = 0;
+            for(std::string::const_reverse_iterator c = maskstring.rbegin();
+                c != maskstring.rend(); c++, bit++) {
 
-        std::stringstream ss;
-        //ss << std::hex << std::setfill('0') << std::internal << std::uppercase
-        //   << "0x" << std::setw(8) << mask;
-
-        if(bits_to_check) {
-            for(int i = 31; i >= 0; i--) {
-                if(bits_to_check & (1 << i)) {
-                    if(mask & (1 << i))
-                        ss << "1";
-                    else
-                        ss << "0";
-                } else {
-                    ss << "x";
+                if(*c == '1') {
+                    mask |= (1 << bit);
+                    bits_to_check |= (1 << bit);
+                } else if(*c == '0') {
+                    bits_to_check |= (1 << bit);
                 }
+
             }
-            ss << "b";
-            yInfo() << "Showing only events with bits: " << ss.str();
+
+            ss.str("");
+            if(bits_to_check) {
+                for(int i = 31; i >= 0; i--) {
+                    if(bits_to_check & (1 << i)) {
+                        if(mask & (1 << i))
+                            ss << "1";
+                        else
+                            ss << "0";
+                    } else {
+                        ss << "x";
+                    }
+                }
+                ss << "b";
+                yInfo() << "Showing only events with bits: " << ss.str();
+            } else {
+                yInfo() << "No valid mask provided - showing all events";
+            }
+
+        } else {
+            yInfo() << "No mask provided - showing all events";
         }
 
         //start the asynchronous and synchronous threads

--- a/src/processing/vHexviewer/vHexviewer.cpp
+++ b/src/processing/vHexviewer/vHexviewer.cpp
@@ -13,8 +13,8 @@ class hexViewer : public RFModule, public Thread {
 private:
 
     vReadPort< vector<AE> > input_port;
-    int mask;
-    int bits_to_check;
+    unsigned int mask;
+    unsigned int bits_to_check;
     int cols;
 
 public:
@@ -125,13 +125,7 @@ public:
                 if(!q) return;
                 for(auto &v : (*q))
                 {
-
-
-                    //make a mask for "care or not care"
-
-                    //do ^ (XOR) for equals
-
-                    if((v._coded_data & mask) == mask) {
+                    if((v._coded_data & bits_to_check) == mask) {
                         if(coli++ % cols == 0) std::cout << std::endl;
                         std::cout << "0x" << std::setw(8) << v._coded_data << " ";
                     }

--- a/src/processing/vHexviewer/vHexviewer.xml
+++ b/src/processing/vHexviewer/vHexviewer.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet type="text/xsl" href="yarpmanifest.xsl"?>
+
+<module>
+    <name>vHexviewer</name>
+    <doxygen-group>processing</doxygen-group>
+    <description>Visualises raw event data in hexadecimal</description>
+    <copypolicy>Released under the terms of the GNU GPL v2.0</copypolicy>
+    <version>1.0</version>
+
+    <description-long>
+      A mask can be provided to only view certain events
+    </description-long>
+
+    <arguments>
+        <param desc="Only show events that match the mask" default="/vPepper"> mask </param>
+    </arguments>
+
+    <authors>
+        <author email="arren.glover@iit.it"> Arren Glover </author>
+    </authors>
+
+     <data>
+        <input>
+            <type>AE</type>
+            <port carrier="tcp">/vHexviewer/AE:i</port>
+            <description>
+                Raw input stream of events
+            </description>
+        </input>
+
+    </data>
+
+</module>


### PR DESCRIPTION
@mcasti-iit - please checkout this branch and compile (make install) event-driven (no sudo). the new ``vHexviewer`` should be available. It will open a port /vHexviewer/AE:i which you need to connect to /zynqGrabber/AE:o with fast_tcp. use ``--mask 0x01`` for example as a mask so that only events with the LSB == 1 is shown.

the printed "==" mean it is a packet break. I can customise the output as you like (i.e. if you want to expert the data to a file etc.)

Give me a call if you have problems. If there are no issues, we can discuss this merge.