### PR TITLE
splitting FPGA-tagged corners in vPreProcess

### DIFF
--- a/lib/include/event-driven/vCodec.h
+++ b/lib/include/event-driven/vCodec.h
@@ -34,6 +34,7 @@ namespace ev {
 #define IS_SSV(x)       x&0x00800000
 #define IS_IMUSAMPLE(x) x&0x02000000
 #define IS_AUDIO(x)     x&0x04000000
+#define IS_CORNER(x)    x&0x00100000
 
 //macros
 class vEvent;

--- a/src/processing/vPreProcess/include/vPreProcess.h
+++ b/src/processing/vPreProcess/include/vPreProcess.h
@@ -53,6 +53,8 @@ private:
     ev::vWritePort out_port_aps_stereo;
     ev::vWritePort out_port_imu_samples;
     ev::vWritePort out_port_audio;
+    ev::vWritePort out_port_crn_left;
+    ev::vWritePort out_port_crn_right;
 
     //parameters
     std::string name;
@@ -80,6 +82,7 @@ private:
     bool split_polarities;
     bool combined_stereo;
     bool use_local_stamp;
+    bool corners;
 
     //timing stats
     std::deque<double> delays;

--- a/src/processing/vPreProcess/include/vPreProcess.h
+++ b/src/processing/vPreProcess/include/vPreProcess.h
@@ -55,6 +55,7 @@ private:
     ev::vWritePort out_port_audio;
     ev::vWritePort out_port_crn_left;
     ev::vWritePort out_port_crn_right;
+    ev::vWritePort out_port_crn_stereo;
 
     //parameters
     std::string name;

--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -102,6 +102,8 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
                       rf.check("combined_stereo", Value(true)).asBool();
     use_local_stamp = rf.check("local_stamp") &&
                       rf.check("local_stamp", Value(true)).asBool();
+    corners = rf.check("corners") &&
+              rf.check("corners", Value(true)).asBool();
 
     if(!split_stereo) combined_stereo = true;
 
@@ -184,6 +186,12 @@ bool vPreProcess::threadInit() {
             return false;
         if(!out_port_aps_right.open(getName() + "/aps_right:o"))
             return false;
+        if(corners) {
+            if(!out_port_crn_left.open(getName() + "/corners/left/AE:o"))
+                return false;
+            if(!out_port_crn_right.open(getName() + "/corners/right/AE:o"))
+                return false;
+        }
     }
     if(combined_stereo) {
         if(split_polarities) {
@@ -195,8 +203,13 @@ bool vPreProcess::threadInit() {
             if(!outPortCamStereo.open(getName() + "/AE:o"))
                 return false;
         }
+        if(corners) {
+            if(!out_port_crn_left.open(getName() + "/corners/AE:o"))
+                return false;
+        }
         if(!out_port_aps_stereo.open(getName() + "/APS:o"))
             return false;
+
     }
 
     if(!out_port_imu_samples.open(getName() + "/imu_samples:o"))
@@ -292,6 +305,7 @@ void vPreProcess::run() {
         std::deque<AE> qleft_aps, qright_aps, qstereo_aps;
         std::deque<int32_t> qimusamples;
         std::deque<int32_t> qaudio;
+        std::deque<AE> qleft_corners, qright_corners;
 
         const std::vector<int32_t> *q = inPort.read(zynq_stamp);
         if(!q) break;
@@ -383,6 +397,8 @@ void vPreProcess::run() {
                         } else {
                             qright.push_back(v);
                         }
+                        if(corners && IS_CORNER(v._coded_data))
+                            qright_corners.push_back(v);
                     } else {
                         if(v.type)
                             qleft_aps.push_back(v);
@@ -395,6 +411,8 @@ void vPreProcess::run() {
                         } else {
                             qleft.push_back(v);
                         }
+                        if(corners && IS_CORNER(v._coded_data))
+                            qleft_corners.push_back(v);
                     }
                 }
                 if(combined_stereo) {
@@ -409,6 +427,8 @@ void vPreProcess::run() {
                     } else {
                         qstereo.push_back(v);
                     }
+                    if(corners && IS_CORNER(v._coded_data))
+                        qleft_corners.push_back(v);
                 }
             }
         }
@@ -494,6 +514,12 @@ void vPreProcess::run() {
         }
         if(qaudio.size()) {
             out_port_audio.write(qaudio, zynq_stamp);
+        }
+        if(qleft_corners.size()) {
+            out_port_crn_left.write(qleft_corners, zynq_stamp);
+        }
+        if(qright_corners.size()) {
+            out_port_crn_right.write(qright_corners, zynq_stamp);
         }
     }
 }

--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -60,6 +60,9 @@ vPreProcess::vPreProcess() : name("/vPreProcess") {
     out_port_aps_right.setWriteType(AE::tag);
     out_port_imu_samples.setWriteType(IMUevent::tag);
     out_port_audio.setWriteType(AE::tag);
+    out_port_crn_left.setWriteType(AE::tag);
+    out_port_crn_right.setWriteType(AE::tag);
+    out_port_crn_stereo.setWriteType(AE::tag);
 }
 
 
@@ -74,6 +77,10 @@ vPreProcess::~vPreProcess() {
     out_port_aps_right.close();
     out_port_imu_samples.close();
     out_port_audio.close();
+    out_port_crn_left.close();
+    out_port_crn_right.close();
+    out_port_crn_stereo.close();
+
 }
 
 bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
@@ -204,7 +211,7 @@ bool vPreProcess::threadInit() {
                 return false;
         }
         if(corners) {
-            if(!out_port_crn_left.open(getName() + "/corners/AE:o"))
+            if(!out_port_crn_stereo.open(getName() + "/corners/AE:o"))
                 return false;
         }
         if(!out_port_aps_stereo.open(getName() + "/APS:o"))
@@ -305,7 +312,7 @@ void vPreProcess::run() {
         std::deque<AE> qleft_aps, qright_aps, qstereo_aps;
         std::deque<int32_t> qimusamples;
         std::deque<int32_t> qaudio;
-        std::deque<AE> qleft_corners, qright_corners;
+        std::deque<AE> qleft_corners, qright_corners, qstereo_corners;
 
         const std::vector<int32_t> *q = inPort.read(zynq_stamp);
         if(!q) break;
@@ -428,7 +435,7 @@ void vPreProcess::run() {
                         qstereo.push_back(v);
                     }
                     if(corners && IS_CORNER(v._coded_data))
-                        qleft_corners.push_back(v);
+                        qstereo_corners.push_back(v);
                 }
             }
         }
@@ -520,6 +527,9 @@ void vPreProcess::run() {
         }
         if(qright_corners.size()) {
             out_port_crn_right.write(qright_corners, zynq_stamp);
+        }
+        if(qstereo_corners.size()) {
+            out_port_crn_stereo.write(qstereo_corners, zynq_stamp);
         }
     }
 }


### PR DESCRIPTION
if the FPGA has the ability to calculate if an event is a corner event, it will set a bit to 1 in the AE of corners. The vPreProcess can "split" corner events out of the main event-stream.

tested on a live camera output