### PR TITLE
update app defaults to fast_tcp instead of udp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build-x86_64/
 build-ubuntu/
 wsl-build/
 build-pc104/
+debug/
 
 *.autosave
 .idea/

--- a/src/applications/autosaccade/app_autosaccade.xml.template
+++ b/src/applications/autosaccade/app_autosaccade.xml.template
@@ -40,31 +40,31 @@
     <connection>
         <from>/zynqGrabber/vBottle:o</from>
         <to>/vPepper/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPepper/vBottle:o</from>
         <to>/autoSaccade/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPepper/vBottle:o</from>
         <to>/vFramer/AE:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vFramer/left</from>
         <to>/viewLeft</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vFramer/right</from>
         <to>/viewRight</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
 </application>

--- a/src/applications/calibrate/app_vCalibChess.xml.template
+++ b/src/applications/calibrate/app_vCalibChess.xml.template
@@ -49,37 +49,37 @@
 <connection>
   <from>/zynqGrabber/AE:o</from>
   <to>/vPreProcess/AE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/right:o</from>
   <to>/vFramer/right/AE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/stefi/cam/right</from>
   <to>/stereoCalib/cam/right:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vFramer/right/image:o</from>
   <to>/stereoCalib/cam/left:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/stereoCalib/cam/right:o</from>
   <to>/viewCh0</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/stereoCalib/cam/left:o</from>
   <to>/viewCh1</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 </application>

--- a/src/applications/corner/app_corner.xml.template
+++ b/src/applications/corner/app_corner.xml.template
@@ -40,43 +40,43 @@
     <connection>
         <from>/zynqGrabber/vBottle:o</from>
         <to>/vPreProcess/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPreProcess/vBottle:o</from>
         <to>/vCorner/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPreProcess/vBottle:o</from>
         <to>/vFramer/AE:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPreProcess/vBottle:o</from>
         <to>/vCorner/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vCorner/vBottle:o</from>
         <to>/vFramer/LAE:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vFramer/left</from>
         <to>/viewLeft</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vFramer/right</from>
         <to>/viewRight</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
 </application>

--- a/src/applications/dualCamTransform/app_dualCamTransform.xml.template
+++ b/src/applications/dualCamTransform/app_dualCamTransform.xml.template
@@ -82,79 +82,79 @@
     <connection>
         <from>/zynqGrabber/vBottle:o</from>
         <to>/vPreProcess/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPreProcess/vBottle:o</from>
         <to>/DualCamTransform/vBottle:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vPreProcess/vBottle:o</from>
         <to>/vFramer/AE:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vFramer/blob/left</from>
         <to>/DualCamTransform/left/vImg:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/vFramer/blob/right</from>
         <to>/DualCamTransform/right/vImg:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/icub/cam/left</from>
         <to>/icub/camcalib/left/in</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/icub/cam/right</from>
         <to>/icub/camcalib/right/in</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/icub/camcalib/left/out</from>
         <to>/imageEnhanceLeft/image:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/icub/camcalib/right/out</from>
         <to>/imageEnhanceRight/image:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/imageEnhanceRight/image:o</from>
         <to>/DualCamTransform/right/img:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/imageEnhanceLeft/image:o</from>
         <to>/DualCamTransform/left/img:i</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/DualCamTransform/left/img:o</from>
         <to>/transformed/left</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
     <connection>
         <from>/DualCamTransform/right/img:o</from>
         <to>/transformed/right</to>
-        <protocol>udp</protocol>
+        <protocol>fast_tcp</protocol>
     </connection>
 
 </application>

--- a/src/applications/gazeDemo/app_vGazeDemo.xml.template
+++ b/src/applications/gazeDemo/app_vGazeDemo.xml.template
@@ -84,43 +84,43 @@
 <connection>
   <from>/zynqGrabber/vBottle:o</from>
   <to>/vPreProcess/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/left:o</from>
   <to>/vFramer/AE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/right:o</from>
   <to>/vFramer/AE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/left:o</from>
   <to>/vpfL/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/right:o</from>
   <to>/vpfR/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vpfL/vBottle:o</from>
   <to>/vFramer/GAE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vpfR/vBottle:o</from>
   <to>/vFramer/GAE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
@@ -138,31 +138,31 @@
 <connection>
   <from>/vpfL/debug:o</from>
   <to>/viewDebugL</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vpfR/debug:o</from>
   <to>/viewDebugR</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vpfL/vBottle:o</from>
   <to>/vGazeDemo/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vpfR/vBottle:o</from>
   <to>/vGazeDemo/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/demoRedBall/cmdFace:rpc</from>
   <to>/icub/face/emotions/in</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 

--- a/src/applications/reptest/vRepTest.xml
+++ b/src/applications/reptest/vRepTest.xml
@@ -43,7 +43,7 @@
         </output>
         <output>
             <type>yarp::os::Bottle</type>
-            <port carrier="udp">/vCircle/scope:o</port>
+            <port carrier="fast_tcp">/vCircle/scope:o</port>
             <description>
                 Outputs debug information for use with yarpscope. The gap
                 between input bottle numbers is written to detect data being
@@ -52,7 +52,7 @@
         </output>
         <output>
             <type>yarp::sig::Image</type>
-            <port carrier="udp">/vCirlce/debug:o</port>
+            <port carrier="fast_tcp">/vCirlce/debug:o</port>
             <description>
                 Outputs a debugging images displaying events in the event-queue
                 as well as the strength of the Hough transform from the same

--- a/src/applications/vergenceDemo/vergenceController/app_vergenceController.xml.template
+++ b/src/applications/vergenceDemo/vergenceController/app_vergenceController.xml.template
@@ -56,13 +56,13 @@
 <connection>
   <from>/zynqGrabber/vBottle:o</from>
   <to>/vPreProcess/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/vBottle:o</from>
   <to>/vVergence/vBottle:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>

--- a/src/applications/vergenceDemo/vergenceController/vergenceController.xml
+++ b/src/applications/vergenceDemo/vergenceController/vergenceController.xml
@@ -24,7 +24,7 @@
      <data>
         <input>
             <type>eventdriven::vBottle</type>
-            <port carrier="udp">/vVergence/vBottle:i</port>
+            <port carrier="fast_tcp">/vVergence/vBottle:i</port>
             <required>yes</required>
             <priority>no</priority>
             <description>
@@ -42,7 +42,7 @@
         </output>
         <output>
             <type>yarp::os::Bottle</type>
-            <port carrier="udp">/vVergence/scopefilters:o</port>
+            <port carrier="fast_tcp">/vVergence/scopefilters:o</port>
             <description>
                 Outputs debug information for use with yarpscope. Energies of
                 several filters are shown with different colors.

--- a/src/applications/view/app_event-viewer-example.xml
+++ b/src/applications/view/app_event-viewer-example.xml
@@ -6,7 +6,7 @@
 
 <module>
     <name> vPreProcess </name>
-    <parameters>--flipx --flipy --split_stereo </parameters>
+    <parameters> --split_stereo </parameters>
     <node> localhost </node>
 </module>
 
@@ -32,31 +32,31 @@
 <connection>
   <from>/zynqGrabber/AE:o</from>
   <to>/vPreProcess/AE:i</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/left:o</from>
   <to>/vFramer/left/AE:i</to>
-  <protocol> udp </protocol>
+  <protocol> fast_tcp </protocol>
 </connection>
 
 <connection>
   <from>/vPreProcess/right:o</from>
   <to>/vFramer/right/AE:i</to>
-  <protocol> udp </protocol>
+  <protocol> fast_tcp </protocol>
 </connection>
 
 <connection>
   <from>/vFramer/left/image:o</from>
   <to>/viewCh0</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 <connection>
   <from>/vFramer/right/image:o</from>
   <to>/viewCh1</to>
-  <protocol>udp</protocol>
+  <protocol>fast_tcp</protocol>
 </connection>
 
 

--- a/src/processing/DualCamTransform/DualCamTransform.xml
+++ b/src/processing/DualCamTransform/DualCamTransform.xml
@@ -44,7 +44,7 @@
 
         <output>
             <type>yarp::sig::Image</type>
-            <port carrier="udp">/vMapping/img:o</port>
+            <port carrier="fast_tcp">/vMapping/img:o</port>
             <description>
                 Image overlapped with events
             </description>
@@ -52,7 +52,7 @@
 
          <output>
             <type>ev::vBottle</type>
-            <port carrier="udp">/vMapping/vBottle:o</port>
+            <port carrier="fast_tcp">/vMapping/vBottle:o</port>
             <description>
                 Transformed events
             </description>

--- a/src/processing/vCircle/vCircle.xml
+++ b/src/processing/vCircle/vCircle.xml
@@ -54,7 +54,7 @@
         </output>
         <output>
             <type>yarp::os::Bottle</type>
-            <port carrier="udp">/vCircle/scope:o</port>
+            <port carrier="fast_tcp">/vCircle/scope:o</port>
             <description>
                 Outputs debug information for use with yarpscope. The gap
                 between input bottle numbers is written to detect data being
@@ -63,7 +63,7 @@
         </output>
         <output>
             <type>yarp::sig::Image</type>
-            <port carrier="udp">/vCirlce/debug:o</port>
+            <port carrier="fast_tcp">/vCirlce/debug:o</port>
             <description>
                 Outputs a debugging images displaying events in the event-queue
                 as well as the strength of the Hough transform from the same

--- a/src/processing/vCorner/vCorner.xml
+++ b/src/processing/vCorner/vCorner.xml
@@ -32,7 +32,7 @@
      <data>
         <input>
             <type>eventdriven::vBottle</type>
-            <port carrier="udp">/vCorner/vBottle:i</port>
+            <port carrier="fast_tcp">/vCorner/vBottle:i</port>
             <required>yes</required>
             <priority>no</priority>
             <description>
@@ -41,7 +41,7 @@
         </input>
         <output>
             <type>eventdriven::vBottle</type>
-            <port carrier="udp">/vCorner/vBottle:o</port>
+            <port carrier="fast_tcp">/vCorner/vBottle:o</port>
             <description>
                 Outputs corner events in the form of an
                 eventdriven::LabelledAE. The vBottle also contains all
@@ -50,7 +50,7 @@
         </output>
         <output>
             <type>yarp::os::Bottle</type>
-            <port carrier="udp">/vCorner/score:o</port>
+            <port carrier="fast_tcp">/vCorner/score:o</port>
             <description>
                 Outputs debug information for use with yarpscope. The gap
                 between the time required to get and process events


### PR DESCRIPTION
in nearly all cases the better option is to use fast_tcp rather than udp (possibly on the robot I'm still not sure). However, by default all .xml applications should have fast_tcp as the default. this PR updates all .xml files to use fast_tcp