### PR TITLE
Adds Windows api export symbols + small fixes for windws compilation

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -49,6 +49,7 @@ set(folder_header
   include/event-driven/vPort.h
   include/event-driven/vCollectSend.h
   include/event-driven/all.h
+  include/event-driven/api.h
 )
 
 if(OpenCV_FOUND)

--- a/lib/include/event-driven/api.h
+++ b/lib/include/event-driven/api.h
@@ -1,0 +1,15 @@
+#ifndef API_H
+#define API_H
+#define EV_API
+
+#ifdef WIN32
+    #define _USE_MATH_DEFINES
+    #undef EV_API
+    #ifdef EXPORT 
+        #define EV_API __declspec(dllexport)
+    #else 
+        #define EV_API __declspec(dllimport)
+    #endif
+#endif
+
+#endif

--- a/lib/include/event-driven/vCodec.h
+++ b/lib/include/event-driven/vCodec.h
@@ -20,6 +20,7 @@
 #define __VCODEC__
 
 #include "event-driven/vtsHelper.h"
+#include <event-driven/api.h>
 #include <memory>
 #include <deque>
 #include <math.h>
@@ -100,7 +101,7 @@ public:
 };
 
 /// \brief an event with a pixel location, camera number and polarity
-class AddressEvent : public vEvent
+class EV_API AddressEvent : public vEvent
 {
 public:
     static const std::string tag;
@@ -138,7 +139,7 @@ public:
 using AE = AddressEvent;
 
 /// \brief an event with a taxel location, body-part and polarity
-class SkinEvent : public vEvent
+class EV_API SkinEvent : public vEvent
 {
 public:
     static const std::string tag;
@@ -176,7 +177,7 @@ public:
 };
 
 /// \brief an event with a taxel location, body-part and polarity
-class SkinSample : public SkinEvent
+class EV_API SkinSample : public SkinEvent
 {
 public:
     static const std::string tag;
@@ -248,7 +249,7 @@ public:
 };
 
 /// \brief a LabelledAE with parameters that define a 2D gaussian
-class GaussianAE : public LabelledAE
+class EV_API GaussianAE : public LabelledAE
 {
 public:
     static const std::string tag;
@@ -275,7 +276,7 @@ public:
 };
 
 /// \brief an event with a pixel location, camera number and polarity
-class IMUevent : public vEvent
+class EV_API IMUevent : public vEvent
 {
 public:
     static const std::string tag;

--- a/lib/include/event-driven/vDraw.h
+++ b/lib/include/event-driven/vDraw.h
@@ -22,6 +22,7 @@
 #ifndef __vDraw__
 #define __vDraw__
 
+#include <event-driven/api.h>
 #include <event-driven/all.h>
 #include <string>
 #include <opencv2/opencv.hpp>
@@ -113,7 +114,7 @@ public:
 
 };
 
-class isoDraw : public vDraw {
+class EV_API isoDraw : public vDraw {
 
 protected:
 
@@ -158,7 +159,7 @@ public:
 
 };
 
-class addressDraw : public vDraw {
+class EV_API addressDraw : public vDraw {
 
 public:
 
@@ -169,7 +170,7 @@ public:
 
 };
 
-class imuDraw : public vDraw {
+class EV_API imuDraw : public vDraw {
 
 public:
 
@@ -180,7 +181,7 @@ public:
 
 };
 
-class rasterDraw : public vDraw {
+class EV_API rasterDraw : public vDraw {
 
 protected:
 
@@ -205,7 +206,7 @@ public:
 
 };
 
-class cochleaDraw : public vDraw {
+class EV_API cochleaDraw : public vDraw {
 
 public:
 
@@ -216,7 +217,7 @@ public:
 
 };
 
-class flowDraw : public vDraw {
+class EV_API flowDraw : public vDraw {
 
 public:
 
@@ -227,7 +228,7 @@ public:
 
 };
 
-class interestDraw : public vDraw {
+class EV_API interestDraw : public vDraw {
 
 public:
 
@@ -238,7 +239,7 @@ public:
 
 };
 
-class clusterDraw : public vDraw {
+class EV_API clusterDraw : public vDraw {
 
 protected:
 
@@ -254,7 +255,7 @@ public:
 
 };
 
-class isoInterestDraw : public isoDraw {
+class EV_API isoInterestDraw : public isoDraw {
 
 public:
 

--- a/lib/include/event-driven/vDrawSkin.h
+++ b/lib/include/event-driven/vDrawSkin.h
@@ -994,7 +994,7 @@ public:
 
 };
 
-class isoDrawSkin : public isoDraw {
+class EV_API isoDrawSkin : public isoDraw {
 
 private:
 
@@ -1026,7 +1026,7 @@ public:
 
 
 
-class skinDraw : public vDraw {
+class EV_API skinDraw : public vDraw {
 
 private:
 
@@ -1077,7 +1077,7 @@ public:
 
 };
 
-class skinsampleDraw : public vDraw {
+class EV_API skinsampleDraw : public vDraw {
 
 
 private:
@@ -1127,7 +1127,7 @@ public:
 };
 
 
-class taxelsampleDraw : public vDraw {
+class EV_API taxelsampleDraw : public vDraw {
 
 public:
     void resetImage(cv::Mat &image){
@@ -1149,7 +1149,7 @@ public:
 
 };
 
-class taxeleventDraw : public vDraw {
+class EV_API taxeleventDraw : public vDraw {
 
 public:
     virtual void resetImage(cv::Mat &image){

--- a/lib/include/event-driven/vPort.h
+++ b/lib/include/event-driven/vPort.h
@@ -18,7 +18,9 @@
 
 #ifndef __VGENPORT__
 #define __VGENPORT__
-
+#if WIN32
+#define SCHED_FIFO 8
+#endif
 #include <vector>
 #include <yarp/os/all.h>
 #include <mutex>

--- a/lib/include/event-driven/vtsHelper.h
+++ b/lib/include/event-driven/vtsHelper.h
@@ -21,6 +21,7 @@
 #define __VTSHELPER__
 
 #include <yarp/os/all.h>
+#include <event-driven/api.h>
 #include <fstream>
 #include <math.h>
 #include <vector>
@@ -28,7 +29,7 @@
 namespace ev {
 
 /// \brief helper class to deal with timestamp conversion and wrapping
-class vtsHelper {
+class EV_API vtsHelper {
 
 private:
 

--- a/lib/src/codecs/codec_AddressEvent.cpp
+++ b/lib/src/codecs/codec_AddressEvent.cpp
@@ -17,6 +17,9 @@
  */
 
 #include <yarp/os/Bottle.h>
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vCodec.h
+#endif
 #include "event-driven/vCodec.h"
 
 #if defined CODEC_128x128

--- a/lib/src/codecs/codec_GaussianAE.cpp
+++ b/lib/src/codecs/codec_GaussianAE.cpp
@@ -15,7 +15,9 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vCodec.h
+#endif
 #include "event-driven/vCodec.h"
 #include "event-driven/vtsHelper.h"
 

--- a/lib/src/codecs/codec_IMUEvent.cpp
+++ b/lib/src/codecs/codec_IMUEvent.cpp
@@ -15,7 +15,9 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vCodec.h
+#endif
 #include "event-driven/vCodec.h"
 
 namespace ev {

--- a/lib/src/codecs/codec_SkinEvent.cpp
+++ b/lib/src/codecs/codec_SkinEvent.cpp
@@ -17,6 +17,9 @@
  */
 
 #include <yarp/os/Bottle.h>
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vCodec.h
+#endif
 #include "event-driven/vCodec.h"
 
 namespace ev {

--- a/lib/src/codecs/codec_SkinSample.cpp
+++ b/lib/src/codecs/codec_SkinSample.cpp
@@ -17,6 +17,9 @@
  */
 
 #include <yarp/os/Bottle.h>
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vCodec.h
+#endif
 #include "event-driven/vCodec.h"
 
 namespace ev {

--- a/lib/src/vCodec.cpp
+++ b/lib/src/vCodec.cpp
@@ -74,7 +74,7 @@ bool temporalSortStraight(const event<> &e1, const event<> &e2) {
 bool temporalSortWrap(const event<> &e1, const event<> &e2)
 {
 
-    if((unsigned int)(std::abs(e1->stamp - e2->stamp)) > vtsHelper::max_stamp/2)
+    if((unsigned int)(std::abs((int)e1->stamp - (int)e2->stamp)) > vtsHelper::max_stamp/2)
         return e1->stamp > e2->stamp;
     else
         return e2->stamp > e1->stamp;

--- a/lib/src/vDraw_ISO.cpp
+++ b/lib/src/vDraw_ISO.cpp
@@ -19,6 +19,9 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vDraw.h
+#endif
 #include "event-driven/vDraw.h"
 
 namespace ev {

--- a/lib/src/vDraw_basic.cpp
+++ b/lib/src/vDraw_basic.cpp
@@ -18,6 +18,10 @@
  *   You should have received a copy of the GNU General Public License
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vDraw.h
+#endif
 #include "event-driven/vDraw.h"
 namespace ev {
 

--- a/lib/src/vDraw_skin.cpp
+++ b/lib/src/vDraw_skin.cpp
@@ -17,6 +17,9 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifdef WIN32
+#define EXPORT //warning, positional define. This should be define before including the vDrawSkin.h
+#endif
 #include "event-driven/vDrawSkin.h"
 #include "event-driven/vDraw.h"
 

--- a/lib/src/vtsHelper.cpp
+++ b/lib/src/vtsHelper.cpp
@@ -17,11 +17,18 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifndef WIN32 
+#include <unistd.h>
+#else
+#define EXPORT//warning, positional define. This should be define before including the vCodec.h
+#endif
+
 #include "event-driven/vtsHelper.h"
 
 #include <sstream>
-#include <unistd.h>
+
 #include <limits>
+
 
 namespace ev {
 


### PR DESCRIPTION
adds the windows compatibility. what was failing was particular static member variables that were used in template inline function, so directly compiled in the user compilation target but not properly exported. in linux you can't see those kind of errors because everything get exported by default. if this is not useful or important feel free to ignore the pull request or closing it. it miss extensive test, i just tested the compilation and the FramerLite application. 