### PR TITLE
change interface for resizeWindow

### DIFF
--- a/src/processing/vPreProcess/src/vPreProcess.cpp
+++ b/src/processing/vPreProcess/src/vPreProcess.cpp
@@ -196,7 +196,7 @@ bool vPreProcess::configure(yarp::os::ResourceFinder &rf) {
 
     if(vis) {
         cv::namedWindow("Event Rate", cv::WINDOW_NORMAL);
-        cv::resizeWindow("Event Rate", cv::Size(480, 360));
+        cv::resizeWindow("Event Rate", 480, 360);
         cv::moveWindow("Event Rate", 580, 62);
     }
 


### PR DESCRIPTION
Small change on resizeWindow() call.
       from: resizeWindow(string, const cv::Size(int, int))
       to:  resizeWindow(string, int, int)
The first is only supported on newer versions of OpenCV, while the last is "more" retro-compatible.