### PR TITLE
vFramer update for ED-cam to RGB calibration

### DIFF
--- a/src/processing/vFramer/include/vFramerLite.h
+++ b/src/processing/vFramer/include/vFramerLite.h
@@ -58,6 +58,7 @@ private:
     BufferedPort< FlexImage > image_port;
     vIPT unwarp;
     bool calib_configured;
+    cv::Size render_size;
 
     bool updateQs();
 
@@ -72,11 +73,11 @@ private:
 
 public:
 
-    channelInstance(string channel_name);
+    channelInstance(string channel_name, cv::Size render_size = cv::Size(-1, -1));
     bool addFrameDrawer(unsigned int width, unsigned int height);
     bool addDrawer(string drawer_name, unsigned int width,
                    unsigned int height, unsigned int window_size, double isoWindow, bool flip);
-
+    
     bool threadInit();
     void run();
     void threadRelease();
@@ -153,6 +154,7 @@ public:
     virtual void draw(cv::Mat &image, const ev::vQueue &eSet, int vTime);
     virtual std::string getDrawType();
     virtual std::string getEventType();
+    virtual void resetImage(cv::Mat &image);
 
 };
 

--- a/src/processing/vFramer/src/other_drawers.cpp
+++ b/src/processing/vFramer/src/other_drawers.cpp
@@ -213,10 +213,15 @@ std::string blackDraw::getEventType()
     return AddressEvent::tag;
 }
 
+void blackDraw::resetImage(cv::Mat &image)
+{
+    if (image.empty())
+        image = cv::Mat(Ylimit, Xlimit, CV_8UC3);
+    image.setTo(0);
+}
+
 void blackDraw::draw(cv::Mat &image, const ev::vQueue &eSet, int vTime)
 {
-    image = cv::Scalar(255, 255, 255);
-
     if(eSet.empty()) return;
     if(vTime < 0) vTime = eSet.back()->stamp;
 
@@ -237,20 +242,8 @@ void blackDraw::draw(cv::Mat &image, const ev::vQueue &eSet, int vTime)
             x = Xlimit - 1 - x;
         }
 
-        image.at<cv::Vec3b>(y, x) = cv::Vec3b(0, 0, 0);
+        image.at<cv::Vec3b>(y, x) = white;
     }
-    /*
-    cv::Mat kernel = (cv::Mat_<float>(3,3) <<
-        1,  1, 1,
-        1, -8, 1,
-        1,  1, 1);
-
-    imgLaplacian = Mat::zeros(img.size());
-    filter2D(img, imgLaplacian, kernel);
-
-    cv::GaussianBlur(image, temp, cv::Size(3,3), 3);
-    cv::addWeighted(temp, 1.5, image, -0.5, 0, image);
-    */
 }
 
 


### PR DESCRIPTION
* vframer has the `--out_height <int>` and `--out_width <int>` parameters that should set the resolution of the output image. 
* The BLACK drawer is now inverted to better display the flashing checkerboard.

@marco-monforte and @GiuliaDAngelo - can you please test these functionalities work. We need to run a stereo calibration (i.e. MONO_CALIBRATION = 0) in which we input both the realsense RGB and the output of 
`vFramerLite --displays "(/edcam (BLACK))" --out_width <real-sense-width> --out_height <real-sense-height>`