### PR TITLE
Fix compilation error in drawRefAxis function

### DIFF
--- a/lib/src/vIPT.cpp
+++ b/lib/src/vIPT.cpp
@@ -490,7 +490,7 @@ cv::Mat drawRefAxis(std::array<double, 4> q){
         z = qz / s;
     }
 
-    std::array<float, 3> r = {a*x, a*y, a*z};
+    std::array<float, 3> r = {static_cast<float>(a*x), static_cast<float>(a*y), static_cast<float>(a*z)};
     return drawRefAxis(r);;
 }
 


### PR DESCRIPTION
In some platforms, you can't have an implicit narrowing cast in inizializer lists, unless the argument is constant. Before this PR, the code resulted in this error:
~~~
2022-02-14T19:54:21.2244330Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/event-driven/lib/src/vIPT.cpp:493:31: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
2022-02-14T19:54:21.2346020Z     std::array<float, 3> r = {a*x, a*y, a*z};
2022-02-14T19:54:21.2446960Z                               ^~~
2022-02-14T19:54:21.2548470Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/event-driven/lib/src/vIPT.cpp:493:31: note: insert an explicit cast to silence this issue
2022-02-14T19:54:21.2649640Z     std::array<float, 3> r = {a*x, a*y, a*z};
2022-02-14T19:54:21.2750520Z                               ^~~
2022-02-14T19:54:21.2851510Z                               static_cast<float>( )
2022-02-14T19:54:21.2945990Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/event-driven/lib/src/vIPT.cpp:493:36: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
2022-02-14T19:54:21.3052730Z     std::array<float, 3> r = {a*x, a*y, a*z};
2022-02-14T19:54:21.3153570Z                                    ^~~
2022-02-14T19:54:21.3255100Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/event-driven/lib/src/vIPT.cpp:493:36: note: insert an explicit cast to silence this issue
2022-02-14T19:54:21.3356110Z     std::array<float, 3> r = {a*x, a*y, a*z};
2022-02-14T19:54:21.3456980Z                                    ^~~
2022-02-14T19:54:21.3558010Z                                    static_cast<float>( )
2022-02-14T19:54:21.3659480Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/event-driven/lib/src/vIPT.cpp:493:41: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
2022-02-14T19:54:21.3760690Z     std::array<float, 3> r = {a*x, a*y, a*z};
2022-02-14T19:54:21.3860890Z                                         ^~~
2022-02-14T19:54:21.3962540Z /Users/runner/work/robotology-superbuild/robotology-superbuild/src/event-driven/lib/src/vIPT.cpp:493:41: note: insert an explicit cast to silence this issue
2022-02-14T19:54:21.4062140Z     std::array<float, 3> r = {a*x, a*y, a*z};
2022-02-14T19:54:21.4163080Z                                         ^~~
2022-02-14T19:54:21.4264100Z                                         static_cast<float>( )
2022-02-14T19:54:21.4364440Z 12 warnings and 3 errors generated.
~~~

Fix https://github.com/robotology/robotology-superbuild/issues/1033 .
