### PR TITLE
Add function to return scarf private parameters

### DIFF
--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -283,11 +283,11 @@ public:
      */
     std::tuple<cv::Size, cv::Size, cv::Size> getScarfParams(void)
     {
-        std::tuple scarf_params = {
+        std::tuple<cv::Size, cv::Size, cv::Size> scarf_params = std::make_tuple(
             count,
             dims,
-            {dims.width/2, dims.height/2}
-        };
+            cv::Size(dims.width/2, dims.height/2)
+        );
         return scarf_params;
     }
 };

--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -151,6 +151,7 @@ private:
     //parameters
     cv::Size count{{0, 0}};
     cv::Size dims{{0, 0}};
+    double border_size = 0.5;
 
     //variables
     cv::Mat img;
@@ -162,7 +163,7 @@ public:
     void initialise(cv::Size img_res, int rf_size, double alpha = 1.0, double C = 0.3)
     {
         if(rf_size % 2) rf_size++;
-        initialise(img_res, {(img_res.width/rf_size)-1, (img_res.height/rf_size)-1}, alpha, C);
+        initialise(img_res, {(img_res.width/rf_size)-2*border_size, (img_res.height/rf_size)-2*border_size}, alpha, C);
     }
 
     void initialise(cv::Size img_res, cv::Size rf_res, double alpha = 1.0, double C = 0.3)
@@ -172,7 +173,7 @@ public:
 
         //size of a receptive field removeing some pixels from the border, make sure the receptive field
         //is an even number
-        dims = {img_res.width / (rf_res.width+1), img_res.height / (rf_res.height+1)};
+        dims = {img_res.width / (rf_res.width+2*border_size), img_res.height / (rf_res.height+2*border_size)};
         if(dims.height%2) {dims.height--;} 
         if(dims.width%2) {dims.width--;}
 
@@ -273,14 +274,20 @@ public:
         else return -1;
     }
 
-    // Return Scarf private parameters
-    // count: Resolution of gamer blocks
-    // dims: Size of receptive field
-    std::tuple<cv::Size, cv::Size> getScarfParams(void)
+    /**
+     * @brief Get the Scarf Params object
+     * 
+     * @return std::tuple<cv::Size count, cv::Size dims, double border_size>
+     *         count        : Resolution of SCARF blocks
+     *         dims         : Size of receptive field
+     *         border_size  : border size (Ex, 0.5 = half size of SCARF block)
+     */
+    std::tuple<cv::Size, cv::Size, double> getScarfParams(void)
     {
         std::tuple scarf_params = {
             count,
-            dims
+            dims,
+            border_size
         };
         return scarf_params;
     }

--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -286,7 +286,7 @@ public:
     {
         int N = -1;
         if (rfs.size()) N = rfs[0].N;
-        std::tuple<cv::Size, cv::Size, cv::Size> scarf_params = std::make_tuple(
+        std::tuple<cv::Size, cv::Size, int, cv::Size> scarf_params = std::make_tuple(
             count,
             dims,
             N,

--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -276,16 +276,20 @@ public:
     /**
      * @brief Get the Scarf Params object
      * 
-     * @return std::tuple<cv::Size count, cv::Size dims, double border_size>
+     * @return std::tuple<cv::Size count, cv::Size dims, int N, cv::Size border_shift>
      *         count        : Resolution of SCARF blocks
      *         dims         : Size of receptive field
+     *         N            : Size of ring buffer in each SCARF block
      *         border_shift : (HARD CORDED) pixel values for shift size to match origin of image and origin of scarf
      */
-    std::tuple<cv::Size, cv::Size, cv::Size> getScarfParams(void)
+    std::tuple<cv::Size, cv::Size, int, cv::Size> getScarfParams(void)
     {
+        int N = -1;
+        if (rfs.size()) N = rfs[0].N;
         std::tuple<cv::Size, cv::Size, cv::Size> scarf_params = std::make_tuple(
             count,
             dims,
+            N,
             cv::Size(dims.width/2, dims.height/2)
         );
         return scarf_params;

--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -167,6 +167,7 @@ public:
     void initialise(cv::Size img_res, cv::Size rf_res, double alpha = 1.0, double C = 0.3)
     {
         img = cv::Mat(img_res, CV_32F);
+        count = rf_res;
 
         //size of a receptive field removeing some pixels from the border, make sure the receptive field
         //is an even number

--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -151,7 +151,6 @@ private:
     //parameters
     cv::Size count{{0, 0}};
     cv::Size dims{{0, 0}};
-    double border_size = 0.5;
 
     //variables
     cv::Mat img;
@@ -163,7 +162,7 @@ public:
     void initialise(cv::Size img_res, int rf_size, double alpha = 1.0, double C = 0.3)
     {
         if(rf_size % 2) rf_size++;
-        initialise(img_res, {(img_res.width/rf_size)-2*border_size, (img_res.height/rf_size)-2*border_size}, alpha, C);
+        initialise(img_res, {(img_res.width/rf_size)-1, (img_res.height/rf_size)-1}, alpha, C);
     }
 
     void initialise(cv::Size img_res, cv::Size rf_res, double alpha = 1.0, double C = 0.3)
@@ -173,7 +172,7 @@ public:
 
         //size of a receptive field removeing some pixels from the border, make sure the receptive field
         //is an even number
-        dims = {img_res.width / (rf_res.width+2*border_size), img_res.height / (rf_res.height+2*border_size)};
+        dims = {img_res.width / (rf_res.width+1), img_res.height / (rf_res.height+1)};
         if(dims.height%2) {dims.height--;} 
         if(dims.width%2) {dims.width--;}
 
@@ -280,14 +279,14 @@ public:
      * @return std::tuple<cv::Size count, cv::Size dims, double border_size>
      *         count        : Resolution of SCARF blocks
      *         dims         : Size of receptive field
-     *         border_size  : border size (Ex, 0.5 = half size of SCARF block)
+     *         border_shift : (HARD CORDED) pixel values for shift size to match origin of image and origin of scarf
      */
-    std::tuple<cv::Size, cv::Size, double> getScarfParams(void)
+    std::tuple<cv::Size, cv::Size, cv::Size> getScarfParams(void)
     {
         std::tuple scarf_params = {
             count,
             dims,
-            border_size
+            {dims.width/2, dims.height/2}
         };
         return scarf_params;
     }

--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <opencv2/opencv.hpp>
+#include <tuple>
 
 namespace ev {
 
@@ -270,6 +271,18 @@ public:
     {
         if(rfs.size()) return rfs[0].N;
         else return -1;
+    }
+
+    // Return Scarf private parameters
+    // count: Resolution of gamer blocks
+    // dims: Size of receptive field
+    std::tuple<cv::Size, cv::Size> getScarfParams(void)
+    {
+        std::tuple scarf_params = {
+            count,
+            dims
+        };
+        return scarf_params;
     }
 };
 


### PR DESCRIPTION
Modification
- Add function `getScarfParams` to return private parameters of scarf
  - to reflect them to other event-driven methods

Next task
- returned parameter `border_shift` is hard-corded. 