### PR TITLE
Change default branch to main in Dockerfiles

### DIFF
--- a/Dockerfile_Ubuntu2004
+++ b/Dockerfile_Ubuntu2004
@@ -70,7 +70,7 @@ RUN yarp check
 
 
 # event-driven
-ARG ED_VERSION=master
+ARG ED_VERSION=main
 RUN cd $CODE_DIR &&\
     git clone --depth 1 --branch $ED_VERSION https://github.com/robotology/event-driven.git &&\
     cd event-driven &&\

--- a/Dockerfile_Ubuntu2204
+++ b/Dockerfile_Ubuntu2204
@@ -70,7 +70,7 @@ RUN yarp check
 
 
 # event-driven
-ARG ED_VERSION=master
+ARG ED_VERSION=main
 RUN cd $CODE_DIR &&\
     git clone --depth 1 --branch $ED_VERSION https://github.com/robotology/event-driven.git &&\
     cd event-driven &&\


### PR DESCRIPTION
master branch will be deleted in the future because we switched default branch to `main`.
So default branch in Dockerfile should be also `main`.