### PR TITLE
FIx issue in `stereo-calibrate.cpp` about the same intrinsic parameter

### DIFF
--- a/cpp_tools/calibration/stereo-calibrate.cpp
+++ b/cpp_tools/calibration/stereo-calibrate.cpp
@@ -97,15 +97,15 @@ public:
         board_size = cv::Size(rf.check("cw", Value(8)).asInt32(), rf.check("ch", Value(6)).asInt32());
 
         //get the intrinsic parameters
-        ResourceFinder calibfinder;
+        ResourceFinder calibfinder1, calibfinder2;
 
         if(!rf.check("cam1cal")) {
             yError() << "please supply camera parameters using --cam1cal <path>";
             return false;
         }
-        calibfinder.setDefault("from", rf.find("cam1cal").asString());
-        calibfinder.configure(0, 0);
-        yarp::os::Bottle params_1 = calibfinder.findGroup("CAMERA_CALIBRATION");
+        calibfinder1.setDefault("from", rf.find("cam1cal").asString());
+        calibfinder1.configure(0, 0);
+        yarp::os::Bottle params_1 = calibfinder1.findGroup("CAMERA_CALIBRATION");
         if(params_1.isNull()) {
             yError() << "Could not find [CAMERA_CALIBRATION] in camera 1 file";
             return false;
@@ -121,9 +121,9 @@ public:
             yError() << "please supply camera parameters using --cam2cal <path>";
             return false;
         }
-        calibfinder.setDefault("from", rf.find("cam2cal").asString());
-        calibfinder.configure(0, 0);
-        yarp::os::Bottle params_2 = calibfinder.findGroup("CAMERA_CALIBRATION");
+        calibfinder2.setDefault("from", rf.find("cam2cal").asString());
+        calibfinder2.configure(0, 0);
+        yarp::os::Bottle params_2 = calibfinder2.findGroup("CAMERA_CALIBRATION");
         if(params_2.isNull()) {
             yError() << "Could not find [CAMERA_CALIBRATION] in camera 2 file";
             return false;


### PR DESCRIPTION
## Related issue
Issue #209 

## Modification
Create two ResourceFinder to separate intrinsic parameters

## Results from `stereo-calibrate.cpp`
- Input1 calib_left.txt
```
[CAMERA_CALIBRATION]

w 640
h 480
fx 528.05
fy 527.836
cx 318.411
cy 218.192
k1 -0.187073
k2 0.127942
p1 6.81033e-05
p2 -0.00011043
```
- Input2 calib_right.txt
```
[CAMERA_CALIBRATION]

w 640
h 480
fx 536.018
fy 535.311
cx 329.051
cy 214.174
k1 -0.182822
k2 0.11623
p1 0.0013475
p2 0.00107552
```

- output stereo.txt
```
[CAMERA_CALIBRATION_CAM1]

w 640
h 480
fx 528.050
fy 527.836
cx 318.411
cy 218.192
k1 -0.187073
k2 0.000000
p1 0.000000
p2 0.000000

[CAMERA_CALIBRATION_CAM2]

w 640
h 480
fx 536.018
fy 535.311
cx 329.051
cy 214.174
k1 -0.182822
k2 -0.000000
p1 0.000000
p2 0.000000

[STEREO_DISPARITY]
HN (0.999489 -0.000614 -0.031962 -0.168992 0.000466 0.999989 -0.004645 -0.003336 0.031964 0.004628 0.999478 0.005467 0 0 0 1)
```