### PR TITLE
Fix output of stereo calibration when `cv::CALIB_ZERO_TANGENT_DIST` is removed

### DIFF
--- a/cpp_tools/calibration/stereo-calibrate.cpp
+++ b/cpp_tools/calibration/stereo-calibrate.cpp
@@ -299,9 +299,9 @@ public:
         writer << "cy " << camera_matrix_1.at<double>(1, 2) << std::endl;
         writer << std::setprecision(6);
         writer << "k1 " << dist_coeffs_1.at<double>(0, 0) << std::endl;
-        writer << "k2 " << dist_coeffs_1.at<double>(1, 0) << std::endl;
-        writer << "p1 " << dist_coeffs_1.at<double>(2, 0) << std::endl;
-        writer << "p2 " << dist_coeffs_1.at<double>(3, 0) << std::endl;
+        writer << "k2 " << dist_coeffs_1.at<double>(0, 1) << std::endl;
+        writer << "p1 " << dist_coeffs_1.at<double>(0, 2) << std::endl;
+        writer << "p2 " << dist_coeffs_1.at<double>(0, 3) << std::endl;
         writer << std::endl;
         writer.flush();
 
@@ -316,9 +316,9 @@ public:
         writer << "cy " << camera_matrix_2.at<double>(1, 2) << std::endl;
         writer << std::setprecision(6);
         writer << "k1 " << dist_coeffs_2.at<double>(0, 0) << std::endl;
-        writer << "k2 " << dist_coeffs_2.at<double>(1, 0) << std::endl;
-        writer << "p1 " << dist_coeffs_2.at<double>(2, 0) << std::endl;
-        writer << "p2 " << dist_coeffs_2.at<double>(3, 0) << std::endl;
+        writer << "k2 " << dist_coeffs_2.at<double>(0, 1) << std::endl;
+        writer << "p1 " << dist_coeffs_2.at<double>(0, 2) << std::endl;
+        writer << "p2 " << dist_coeffs_2.at<double>(0, 3) << std::endl;
         writer << std::endl;
         writer.flush();
 

--- a/cpp_tools/calibration/stereo-calibrate.cpp
+++ b/cpp_tools/calibration/stereo-calibrate.cpp
@@ -275,7 +275,7 @@ public:
         object_points.resize(image_points_1.size(), object_points[0]);
 
         // call calibrate camera
-        cv::stereoCalibrate(object_points, image_points_1, image_points_2, camera_matrix_1, dist_coeffs_1, camera_matrix_2, dist_coeffs_2, img_size_1, R, T, E, F, cv::CALIB_FIX_INTRINSIC|cv::CALIB_ZERO_TANGENT_DIST);
+        cv::stereoCalibrate(object_points, image_points_1, image_points_2, camera_matrix_1, dist_coeffs_1, camera_matrix_2, dist_coeffs_2, img_size_1, R, T, E, F, cv::CALIB_FIX_INTRINSIC);
         cv::Mat R1, R2, P1, P2;
         cv::stereoRectify(camera_matrix_1, dist_coeffs_1, camera_matrix_2, dist_coeffs_2, 
                     img_size_1, R, T, R1, R2, P1, P2, cv::noArray());


### PR DESCRIPTION
## Issue
- When I remove the flag `cv::CALIB_ZERO_TANGENT_DIST` for stereo calibration, I found the issue that output file does not include k2 ~ p2 values as intrinsic parameters.

## Modification
- Remove the flag `cv::CALIB_ZERO_TANGENT_DIST`
- Fix address of cv::Mat when these values are written in the output txt file