### PR TITLE
zynqGrabber stability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,14 @@ endif()
 add_subdirectory(ev2)
 
 #build additional tools
+set(VLIB_FORCESLIM OFF CACHE BOOL "force lightweight build")
+if(VLIB_FORCESLIM)
+  message(STATUS "OFF: applications using opencv and drivers not compiled")
+  set(OpenCV_FOUND OFF)
+  set(MetavisionSDK_FOUND OFF)
+  set(prophesee_core_FOUND OFF)
+endif()
+
 add_subdirectory(cpp_tools)
 
 #install the package

--- a/cpp_tools/log2vid/log2vid.cpp
+++ b/cpp_tools/log2vid/log2vid.cpp
@@ -2,15 +2,12 @@
 #include <string>
 #include <fstream>
 #include <iostream>
-#include <filesystem>
 #include <vector>
 #include <opencv2/opencv.hpp>
 #include <event-driven/core.h>
 #include <event-driven/algs.h>
 #include <event-driven/vis.h>
 
-//using yarp::os::ResourceFinder;
-namespace fs = std::filesystem;
 using yarp::os::Value;
 
 void helpfunction() 
@@ -76,7 +73,7 @@ int main(int argc, char* argv[])
     yInfo() << "Loading log file ... ";
     if(!loader.load(file_path)) {
         yError() << "Could not open log file";
-        return false;
+        return -1;
     } else {
         yInfo() << loader.getinfo();
     }

--- a/cpp_tools/vFramer/drawers.cpp
+++ b/cpp_tools/vFramer/drawers.cpp
@@ -85,9 +85,9 @@ bool drawerInterface::threadInit()
 bool drawerInterfaceAE::initialise(const std::string &name, int height, int width, double window_size, bool yarp_publish, const std::string &remote) 
 {
     this->name = name;
-    srand (time(NULL));
     std::stringstream ss;
-    ss << "/vFramer/" << rand()%10000 << "/AE:i";
+    ss << "/vFramer/" << (int)(yarp::os::Time::now())<< "/AE:i";
+    yarp::os::Time::delay(1);
     this->portName = ss.str();
     this->sourceName = remote;
     this->yarp_publish = yarp_publish;

--- a/cpp_tools/zynqGrabber/hpuInterface.h
+++ b/cpp_tools/zynqGrabber/hpuInterface.h
@@ -112,13 +112,21 @@ private:
 
             double toc = yarp::os::Time::now();
 
+            unsigned int coded;
             //sort the events
             for(size_t i = 0; i < events_read; i++) {
                 ev::AE &event = buffer[i];
                 if(event.skin) {
                     //SKIN
                     packet_skin->push_back(event);
+                // } else if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
+                //     memcpy(&coded, &event, sizeof(unsigned int));
+                //     std::cout << std::hex << coded;
                 } else {
+                    if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
+                        memcpy(&coded, &event, sizeof(unsigned int));
+                        std::cout << std::hex << coded;
+                    }
                     //VISION
                     if(params.filter > 0.0 && !refrac.check(event, toc)) {
                         d2y_filtered++;

--- a/cpp_tools/zynqGrabber/hpuInterface.h
+++ b/cpp_tools/zynqGrabber/hpuInterface.h
@@ -112,7 +112,6 @@ private:
 
             double toc = yarp::os::Time::now();
 
-            unsigned int coded;
             //sort the events
             for(size_t i = 0; i < events_read; i++) {
                 ev::AE &event = buffer[i];

--- a/cpp_tools/zynqGrabber/hpuInterface.h
+++ b/cpp_tools/zynqGrabber/hpuInterface.h
@@ -122,11 +122,14 @@ private:
                 // } else if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
                 //     memcpy(&coded, &event, sizeof(unsigned int));
                 //     std::cout << std::hex << coded;
+	    	} else if(event.x > 640 || event.y > 480) {
+			yWarning() << "[" << event.x << "," << event.y << "]";
                 } else {
-                    if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
-                        memcpy(&coded, &event, sizeof(unsigned int));
-                        std::cout << std::hex << coded;
-                    }
+                    //if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
+                    //    memcpy(&coded, &event, sizeof(unsigned int));
+                    //   std::cout << "0x" << std::hex << coded << " " << std::endl;
+                    //}
+
                     //VISION
                     if(params.filter > 0.0 && !refrac.check(event, toc)) {
                         d2y_filtered++;

--- a/cpp_tools/zynqGrabber/hpuInterface.h
+++ b/cpp_tools/zynqGrabber/hpuInterface.h
@@ -119,17 +119,9 @@ private:
                 if(event.skin) {
                     //SKIN
                     packet_skin->push_back(event);
-                // } else if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
-                //     memcpy(&coded, &event, sizeof(unsigned int));
-                //     std::cout << std::hex << coded;
-	    	} else if(event.x > 640 || event.y > 480) {
-			yWarning() << "[" << event.x << "," << event.y << "]";
+	    	    } else if(event.x > params.roi_max_x || event.y > params.roi_max_y) {
+			        yWarning() << "[" << event.x << "," << event.y << "]";
                 } else {
-                    //if(event.corner || event.type || event._fill || event.x > 640 || event.y > 480) {
-                    //    memcpy(&coded, &event, sizeof(unsigned int));
-                    //   std::cout << "0x" << std::hex << coded << " " << std::endl;
-                    //}
-
                     //VISION
                     if(params.filter > 0.0 && !refrac.check(event, toc)) {
                         d2y_filtered++;
@@ -250,6 +242,8 @@ public:
         unsigned int max_packet_size{8*7500};
         bool split{false};
         double filter{0.0};
+        int roi_max_x{640};
+        int roi_max_y{480};
 
     } params;
 

--- a/cpp_tools/zynqGrabber/zynqGrabber.ini
+++ b/cpp_tools/zynqGrabber/zynqGrabber.ini
@@ -1,12 +1,167 @@
 dataDevice /dev/iit-hpu0
 hpu_read
+packet_size   7500 #these are in number of events
 gtp
 split
-#hpu_write
-packet_size   7500
 
 i2cVision /dev/i2c-0
+
+#visCtrlLeft /dev/i2c-0
+#visCtrlRight /dev/i2c-0
 #skinCtrl /dev/i2c-3
 
-sensitivity 60
+#visLeftOn true
+#visRightOn false
+#left_off true
+#right_off true
+sensitivity 70
 refractory 1
+filter 0.0001
+
+[ATIS_ROI]
+x 0
+y 0
+width 640
+height 480
+
+
+[ATIS1_BIAS_LEFT]
+
+CtrlbiasLP          1800   967  620
+CtrlbiasLBBuff      1800   967  950
+CtrlbiasDelTD       1800   967  400
+CtrlbiasSeqDelAPS   1800   967  320
+CtrlbiasDelAPS      1800   967  350
+biasSendReqPdY      1800   967  850
+biasSendReqPdX      1800   967  1150
+CtrlbiasGB          1800   711  1150
+TDbiasReqPuY        1800   711  200
+TDbiasReqPuX        1800   711  1200
+APSbiasReqPuY       1800   711  1100
+APSbiasReqPuX       1800   711  830
+APSVrefL            3300   967  3000
+APSVrefH            3300   967  3200
+APSbiasOut          3300   967  660
+APSbiasHyst         3300   967  455
+APSbiasTail         3300   967  520
+TDbiasCas           3300   839  2000
+TDbiasInv           3300   967  800
+TDbiasDiffOff       3300   967  450
+TDbiasDiffOn        3300   967  625
+TDbiasDiff          3300   967  500
+TDbiasFo            3300   711  3050
+TDbiasRefr          3300   711  2850
+TDbiasPR            3300   711  2800
+TDbiasBulk          3300   711  2680
+biasBuf             3300   967  0
+biasAPSreset        3300   711  1000
+
+[ATIS1_BIAS_RIGHT]
+
+CtrlbiasLP          1800   967  620
+CtrlbiasLBBuff      1800   967  950
+CtrlbiasDelTD       1800   967  400
+CtrlbiasSeqDelAPS   1800   967  320
+CtrlbiasDelAPS      1800   967  350
+biasSendReqPdY      1800   967  850
+biasSendReqPdX      1800   967  1150
+CtrlbiasGB          1800   711  1150
+TDbiasReqPuY        1800   711  200
+TDbiasReqPuX        1800   711  1200
+APSbiasReqPuY       1800   711  1100
+APSbiasReqPuX       1800   711  830
+APSVrefL            3300   967  3000
+APSVrefH            3300   967  3200
+APSbiasOut          3300   967  660
+APSbiasHyst         3300   967  455
+APSbiasTail         3300   967  520
+TDbiasCas           3300   839  2000
+TDbiasInv           3300   967  800
+TDbiasDiffOff       3300   967  450
+TDbiasDiffOn        3300   967  625
+TDbiasDiff          3300   967  500
+TDbiasFo            3300   711  3050
+TDbiasRefr          3300   711  2850
+TDbiasPR            3300   711  2800
+TDbiasBulk          3300   711  2680
+biasBuf             3300   967  0
+biasAPSreset        3300   711  1000
+
+[DVS_BIAS_LEFT]
+
+cas 52458
+injg 101508
+reqPd 16777215
+pux 8053457
+diffoff 133
+req 160712
+refr 944
+puy 16777215
+diffon 639172
+diff 30108
+foll 20
+pr 5
+
+[DVS_BIAS_RIGHT]
+
+cas 52458
+injg 101508
+reqPd 16777215
+pux 8053457
+diffoff 133
+req 160712
+refr 944
+puy 16777215
+diffon 639172
+diff 30108
+foll 20
+pr 5
+
+[SKIN_CNFG]
+samplesTxEn         true
+eventsTxEn          true
+
+asrFilterType       false
+asrFilterEn         false
+egNthrEn            true
+preprocSamples      true
+preprocEg           true
+driftCompEn         false
+samplesTxMode       true
+# enable 16 bits coding (true) or 8 bits coding (false)
+samplesRshift       0
+# if samples TxMode = false needs to set the shift value
+samplesSel          false
+#Samples source (0: pre-proc, 1: post-preproc);
+resamplingTimeout   50
+#timebase 50ns
+
+evGenSel 1
+
+G1upthresh 0.1
+G1downthresh 0.1
+G1upnoise 12.0
+G1downnoise 12.0
+
+G2upthresh 30
+G2downthresh 30
+G2upnoise 50
+G2downnoise 50
+
+#evNeuralUseSA1
+SA1inhibit 524288
+SA1adapt   328
+SA1decay   -328
+SA1rest    2621
+
+#evNeuralUseRA1
+RA1inhibit 327680
+RA1adapt   3
+RA1decay   -6552
+RA1rest    65536
+
+evNeuralUseRA2
+RA2inhibit 327680
+RA2adapt   3
+RA2decay   -3276
+RA2rest    2621

--- a/cpp_tools/zynqGrabber/zynqModule.cpp
+++ b/cpp_tools/zynqGrabber/zynqModule.cpp
@@ -40,7 +40,7 @@ class zynqGrabberModule : public yarp::os::RFModule {
     hpuInterface hpu;
 
    public:
-    bool configure(yarp::os::ResourceFinder &rf) {
+    bool configure(yarp::os::ResourceFinder &rf) override {
 
         if(rf.check("help")) {
             yInfo() << "ZYNQGRABBER: DIRECT FROM PROPHESEE TO YOU!";
@@ -61,6 +61,7 @@ class zynqGrabberModule : public yarp::os::RFModule {
             yInfo() << "--packet_size <int>[5120]: standard events in packet (not enforced)";
             yInfo() << "--split <bool>[false]: split data in channels";
             yInfo() << "--filter <double>[0.0]: temporal filter of vision (ms) 0.0 = off";
+            return false;
         }
 
         setName(rf.check("name", yarp::os::Value("/zynqGrabber")).asString().c_str());

--- a/ev2/event-driven/algs/corner.h
+++ b/ev2/event-driven/algs/corner.h
@@ -39,7 +39,6 @@ private:
     std::thread harris_thread;
     std::mutex m;
     std::condition_variable signal;
-    bool eros_updated;
     
     double threshold{0.0};
     double score_mean{0.0};

--- a/ev2/event-driven/algs/flow.h
+++ b/ev2/event-driven/algs/flow.h
@@ -119,7 +119,7 @@ private:
 
     // cv::Mat sae;
     double tolerance{0.125};
-    double refracotry_period{0.003};
+    //double refracotry_period{0.003};
     double dt{0.05};
     size_t N{30};
 

--- a/ev2/event-driven/core/codec.cpp
+++ b/ev2/event-driven/core/codec.cpp
@@ -21,7 +21,7 @@
 const std::string ev::timeStamp::tag = "TS";
 const std::string ev::addressEvent::tag = "AE";
 const std::string ev::encoded::tag="AE";
-const std::string ev::skinAE::tag = "SKE";
+const std::string ev::skinAE::tag = "AE";
 const std::string ev::skinSample::tag = "SKS";
 const std::string ev::flowEvent::tag = "FLOW";
 const std::string ev::gaussianEvent::tag = "GAE";

--- a/ev2/event-driven/core/codec.h
+++ b/ev2/event-driven/core/codec.h
@@ -52,17 +52,9 @@ typedef struct encoded : public timeStamp {
 typedef struct skinAE : public timeStamp {
     static const std::string tag;
     unsigned int polarity:1;
-    unsigned int taxel:10;
-    unsigned int _reserved1:2;
-    unsigned int cross_base:1;
-    unsigned int _sample:1;
-    unsigned int _error:1;
-    unsigned int body_part:3;
-    unsigned int _reserved2:3;
-    unsigned int side:1;
-    unsigned int type:1;
-    unsigned int skin:1;
-    unsigned int _fill:7;
+    unsigned int taxel:4;
+    unsigned int device:4;
+    unsigned int constant:23;
 } skinAE;
 
 typedef struct skinValue {

--- a/ev2/event-driven/core/comms.h
+++ b/ev2/event-driven/core/comms.h
@@ -162,7 +162,7 @@ public:
         return e;
     }
 
-    int fillFromMemory(char *s, int bytes)
+    int fillFromMemory(const char *s, int bytes)
     {
         n_elements = bytes / sizeof(T);
         buffer.resize(n_elements);

--- a/ev2/event-driven/core/utilities.h
+++ b/ev2/event-driven/core/utilities.h
@@ -47,13 +47,13 @@ extern double vtsscaler;
 /// a flag to read if individual event timestamps are enabled
 extern bool ts_status;
 
-static double ticksToSeconds(const unsigned int tick)
+static inline double ticksToSeconds(const unsigned int tick)
 {
     (void)ticksToSeconds;
     return tick * tsscaler;
 }
 
-static unsigned int secondsToTicks(const double seconds)
+static inline unsigned int secondsToTicks(const double seconds)
 {
     (void)secondsToTicks;
     return seconds * vtsscaler;
@@ -71,7 +71,7 @@ static double deltaS(const int current_tick, const int prev_tick)
     return deltaTicks(current_tick, prev_tick) * tsscaler;
 }
 
-static double deltaMS(const int current_tick, const int prev_tick)
+static inline double deltaMS(const int current_tick, const int prev_tick)
 {
     (void)deltaMS;
     return deltaS(current_tick, prev_tick) * 1000.0;


### PR DESCRIPTION
updated several files for:
  - warning free compilation on the robot
  - check to remove visual events outside of retina bounds
  - option in cmake to compile only necessary appliations VLIB_FORCESLIM