### PR TITLE
Support to run event-driven on MacOS

### DIFF
--- a/ev2/event-driven/algs/surface.h
+++ b/ev2/event-driven/algs/surface.h
@@ -167,7 +167,7 @@ public:
 
     void initialise(cv::Size img_res, cv::Size rf_res, double alpha = 1.0, double C = 0.3)
     {
-        img = cv::Mat(img_res, CV_32F);
+        img = cv::Mat::zeros(img_res, CV_32F);
         count = rf_res;
 
         //size of a receptive field removeing some pixels from the border, make sure the receptive field

--- a/ev2/event-driven/core/comms.h
+++ b/ev2/event-driven/core/comms.h
@@ -308,7 +308,7 @@ public:
         using pointer           = T*;
         using reference         = T&;
 
-        iterator() : m_ptr(nullptr) {}
+        iterator() : m_ptr() {}
         void setAsEnd(typename std::list< packet<T>* >::iterator last)
         {
             m_ptr = (**last).end();
@@ -864,7 +864,7 @@ public:
         private:
             int _id{-1};
             double _timestamp{0.0};
-            typename packet<T>::iterator m_ptr{nullptr};
+            typename packet<T>::iterator m_ptr{};
             typename std::list< packet<T> >::iterator packet_it;
             typename std::list< packet<T> >::iterator final;
     };


### PR DESCRIPTION
### Issue 1
In the initialise function, ```img = cv::Mat(img_res, CV_32F);``` will create an img Mat with some random float value on MacOS.

So, I solved it by modifing ```img = cv::Mat(img_res, CV_32F);```  to ```img = cv::Mat::zeros(img_res, CV_32F);```

### Issue 2

MacOS only supports compiler ```clang```. clang cannot compile ```iterator() : m_ptr(nullptr) {}```, which report error as:
```
/Users/ryan/Code/pkg/event-driven/ev2/event-driven/core/comms.h:311:22: error: field of type 'typename packet<addressEvent>::iterator' (aka '__wrap_iter<ev::addressEvent *>') has private constructor
        iterator() : m_ptr(nullptr) {}
                     ^
/Users/ryan/Code/pkg/event-driven/ev2/event-driven/core/comms.h:597:5: note: in instantiation of member function 'ev::window<ev::addressEvent>::iterator::iterator' requested here
    window()
    ^
/Users/ryan/Code/pkg/event-driven/cpp_tools/vFramer/drawers.h:66:7: note: in instantiation of member function 'ev::window<ev::addressEvent>::window' requested here
class drawerInterfaceAE : public drawerInterface 
      ^
/Users/ryan/.local/share/mamba/envs/stereo/bin/../include/c++/v1/__iterator/wrap_iter.h:94:64: note: declared private here
  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit __wrap_iter(iterator_type __x) _NOEXCEPT : __i_(__x) {}
                                                               ^
1 error generated.
```
So, I solved it by modifing ```iterator() : m_ptr(nullptr) {}``` to ```iterator() : m_ptr() {}``` and ```typename packet<T>::iterator m_ptr{nullptr}``` to ```typename packet<T>::iterator m_ptr{}```