### PR TITLE
Add fisheye calibration, getK, getRes, and zynqGrabber building option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ if(VLIB_FORCESLIM)
   set(prophesee_core_FOUND OFF)
 endif()
 
+option(BUILD_ZYNQGRABBER "Build the zynqGrabber module" ON)
 add_subdirectory(cpp_tools)
 
 #install the package

--- a/cpp_tools/CMakeLists.txt
+++ b/cpp_tools/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(zynqGrabber)
+if(BUILD_ZYNQGRABBER)
+  add_subdirectory(zynqGrabber)
+endif()
 add_subdirectory(hexViewer)
 
 #add_subdirectory(binaryDumper)

--- a/ev2/event-driven/vis/IPT.h
+++ b/ev2/event-driven/vis/IPT.h
@@ -36,6 +36,7 @@ private:
     cv::Mat projection[2];
     cv::Mat rotation[2];
     cv::Mat Q;
+    std::string distortion_model;
 
     cv::Mat point_forward_map[2];
     cv::Mat point_reverse_map[2];
@@ -52,6 +53,8 @@ public:
     vIPT();
 
     const cv::Mat& getQ();
+    const cv::Mat& getK(int cam = 0);
+    const cv::Size& getRes(int cam = 0);
     void setProjectedImageSize(int height, int width);
     bool configure(const std::string &calib_file_path, int size_scaler = 2);
     bool showMapProjections(double seconds = 0);


### PR DESCRIPTION
### Modifications

1. Create the functions on undistortion and rectification for quidistant distortion (cv::fisheye). This requires the yarp calibration file to add a new parameter ```distortion_model```: b'radtan' or equidistant.
3. Add the way to get the camera's intrinsic parameters.
4. Add the way to get the camera's resolution.
5. Add an option for building zynqGrabber.