### PR TITLE
Adding support filter and print camera biases

### DIFF
--- a/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
+++ b/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
@@ -203,7 +203,7 @@ public:
 
             if(nf_param > 0.0) {
                  yInfo() << "[REFR FILTER] ON";
-                yInfo() << "  refractory filter:" << nf_param << "seconds";
+                yInfo() << "  refractory filter: " << nf_param << " seconds";
                 nf.use_temporal_filter(nf_param);
             }
 

--- a/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
+++ b/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
@@ -83,9 +83,11 @@ public:
             yInfo() << "--file <str>\t: (optional) provide file path otherwise search for camera to connect";
             yInfo() << "--limit <int>\t: (optional) provide a hard limit on event rate (in 10^6 events/s)";
             yInfo() << "--s   <int>\t: camera sensitivity (0->100)";
-            yInfo() << "--refr_filter <float>\t: temporal filter (seconds) to limit event rate";
-            yInfo() << "--sppt_filter <float>\t: spatial filter (seconds) to limit event rate";
-            yInfo() << "--print_biases\t: show  ALL camera biases";
+            yInfo() << "--refr_filter <float>\t: temporal (refractory) filter window (seconds)";
+            yInfo() << "--filter <float>\t: (deprecated) alias for --refr_filter";
+            yInfo() << "--f <float>\t: (deprecated) alias for --refr_filter";
+            yInfo() << "--sppt_filter <float>\t: spatial support filter window (seconds)";
+            yInfo() << "--print_biases\t: show all available camera biases"
             return false;
         }
 

--- a/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
+++ b/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
@@ -209,7 +209,7 @@ public:
 
             if(sppt_filter > 0.0) {
                 yInfo() << "[SPPT FILTER] ON";
-                yInfo() << "  support filter:" << sppt_filter << "seconds";
+                yInfo() << "  support filter: " << sppt_filter << " seconds";
                 nf.use_spatial_filter(sppt_filter);
             }
         }

--- a/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
+++ b/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
@@ -83,6 +83,9 @@ public:
             yInfo() << "--file <str>\t: (optional) provide file path otherwise search for camera to connect";
             yInfo() << "--limit <int>\t: (optional) provide a hard limit on event rate (in 10^6 events/s)";
             yInfo() << "--s   <int>\t: camera sensitivity (0->100)";
+            yInfo() << "--refr_filter <float>\t: temporal filter (seconds) to limit event rate";
+            yInfo() << "--sppt_filter <float>\t: spatial filter (seconds) to limit event rate";
+            yInfo() << "--print_biases\t: show  ALL camera biases";
             return false;
         }
 
@@ -114,6 +117,11 @@ public:
         buffer.emplace_back();
 
         Biases &bias = cam.biases();
+
+        if(rf.check("print_biases")) {
+            show_biases();
+        }
+
         int bias_pol = 0;
         if(rf.check("polarity"))
             bias_pol = rf.find("polarity").asInt32();
@@ -180,14 +188,30 @@ public:
         yInfo() << "[" << geo.width() << "x" << geo.height() << "]";
 
         double nf_param = 0.0;
+        double sppt_filter = 0.0;
+        if(rf.check("refr_filter")) nf_param = rf.find("refr_filter").asFloat64();
         if(rf.check("filter")) nf_param = rf.find("filter").asFloat64();
-        if(rf.check("f")) nf_param = rf.find("f").asFloat64();
-        if(nf_param > 0.0) 
+
+        if(rf.check("sppt_filter")) sppt_filter = rf.find("sppt_filter").asFloat64();
+
+        
+        if(nf_param > 0.0 || sppt_filter > 0.0)
         {
-            yInfo() << "[FILTER] ON. Maximum 1 event per pixel per" << nf_param << "seconds";
             nf.initialise(geo.width(), geo.height());
-            nf.use_temporal_filter(nf_param);
+
+            if(nf_param > 0.0) {
+                 yInfo() << "[REFR FILTER] ON";
+                yInfo() << "  refractory filter:" << nf_param << "seconds";
+                nf.use_temporal_filter(nf_param);
+            }
+
+            if(sppt_filter > 0.0) {
+                yInfo() << "[SPPT FILTER] ON";
+                yInfo() << "  support filter:" << sppt_filter << "seconds";
+                nf.use_spatial_filter(sppt_filter);
+            }
         }
+
 
         //set the module name used to name ports
         if(gen3) {
@@ -378,6 +402,32 @@ public:
         cv::imshow("clock synch", img);
         cv::waitKey(10);
 
+    }
+
+    void show_biases()
+    {
+    #if defined MetavisionSDK_FOUND
+        try {
+            Biases &bias = cam.biases();
+            I_LL_Biases* bias_control = bias.get_facility();
+
+            if(!bias_control) {
+                yWarning() << "Bias control facility is not available for this camera.";
+                return;
+            }
+
+            std::map<std::string, int> bias_vals = bias_control->get_all_biases();
+
+            yInfo() << "Camera biases:";
+            for(const auto& b : bias_vals) {
+                yInfo() << "  " << b.first << "=" << b.second;
+            }
+
+        } catch(const std::exception& e) {
+            yWarning() << "Could not read camera biases:" << e.what();
+        }
+    #endif
+    
     }
 };
 

--- a/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
+++ b/cpp_tools/atis3-bridge/atis-bridge-sdk.cpp
@@ -428,8 +428,16 @@ public:
         } catch(const std::exception& e) {
             yWarning() << "Could not read camera biases:" << e.what();
         }
+    #else
+        try {
+            Biases &bias = cam.biases();
+            yInfo() << "Camera biases:";
+            yInfo() << "  Sensitivity=" << bias.get_contrast_sensitivity();
+            yInfo() << "  PolaritySwing=" << bias.get_contrast_sensitivity_to_polarity();
+        } catch(const std::exception& e) {
+            yWarning() << "Could not read camera biases:" << e.what();
+        }
     #endif
-    
     }
 };
 


### PR DESCRIPTION
This pull request adds new features to the `atis3-bridge-sdk.cpp` tool, introducing advanced filtering options and a utility to display camera biases. The main updates are the addition of temporal and spatial event rate filters, and a new command-line option to print all camera biases for diagnostic purposes.

**New filtering options:**

* Added support for a temporal (refractory) filter via the `--refr_filter` argument, allowing users to limit event rates based on time intervals. [[1]](diffhunk://#diff-f9dd563265b463d5e5065d58056f2eaed4de6f952dd6829ef599b3f89d12ffa9R86-R88) [[2]](diffhunk://#diff-f9dd563265b463d5e5065d58056f2eaed4de6f952dd6829ef599b3f89d12ffa9R191-R215)
* Added support for a spatial filter via the `--sppt_filter` argument, enabling event rate limitation based on spatial criteria. [[1]](diffhunk://#diff-f9dd563265b463d5e5065d58056f2eaed4de6f952dd6829ef599b3f89d12ffa9R86-R88) [[2]](diffhunk://#diff-f9dd563265b463d5e5065d58056f2eaed4de6f952dd6829ef599b3f89d12ffa9R191-R215)
* Updated filter initialization logic to handle both temporal and spatial filters, including new log messages to indicate which filters are enabled and their parameters.

**Camera bias utilities:**

* Introduced the `--print_biases` command-line option to display all available camera biases, aiding in debugging and calibration. [[1]](diffhunk://#diff-f9dd563265b463d5e5065d58056f2eaed4de6f952dd6829ef599b3f89d12ffa9R86-R88) [[2]](diffhunk://#diff-f9dd563265b463d5e5065d58056f2eaed4de6f952dd6829ef599b3f89d12ffa9R120-R124)
* Implemented the `show_biases()` method to retrieve and print all camera bias values, with error handling for unavailable facilities.

These changes enhance the tool's configurability and provide better insight into camera settings for users.